### PR TITLE
Enforce extra="forbid" on all Pydantic models

### DIFF
--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -13,7 +13,7 @@ from ..core.types import NPARRAY
 
 logger = logging.getLogger(__name__)
 
-class BBAData(BaseModel):
+class BBAData(BaseModel, extra="forbid"):
     """
     A class to hold the data collected during a BBA measurement.
     It contains the BPM positions and the orbit data.
@@ -82,7 +82,7 @@ def hysteresis_loop(name, settings, delta, n_cycles=1, bipolar=True):
         settings.set(name, sp0)
     yield BBACode.HYSTERESIS_DONE
 
-class BBA_Measurement(BaseModel):
+class BBA_Measurement(BaseModel, extra="forbid"):
     """
     A class to perform a beam-based alignment measurement to find the quadrupole center in a storage ring.
     It sets the quadrupole and corrector strengths, collects orbit data.
@@ -362,6 +362,7 @@ class BBAAnalysis(BaseModel):
     rejected_outliers: int
     rejected_slopes: int
     rejected_centers: int
+    total_rejections: int = 0
 
     bpm_outlier_sigma: float
     slope_cutoff: float
@@ -371,7 +372,7 @@ class BBAAnalysis(BaseModel):
     default_slope_cutoff: ClassVar[float] = 0.10 # of max slope
     default_center_cutoff: ClassVar[int] = 1 # number of sigma
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     @classmethod
     def analyze(cls, data: BBAData, n_downstream: Optional[int] = None, bpm_outlier_sigma: Optional[float] = None,

--- a/pySC/apps/dispersion.py
+++ b/pySC/apps/dispersion.py
@@ -41,7 +41,7 @@ class DispersionData(BaseModel):
     timestamp: Optional[float] = None
     original_save_path: Optional[str] = None
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     @property
     def frequency_response(self) -> Tuple[NPARRAY]:
@@ -63,7 +63,7 @@ class DispersionData(BaseModel):
         return filename
 
 
-class DispersionMeasurement(BaseModel):
+class DispersionMeasurement(BaseModel, extra="forbid"):
     delta: float
     shots_per_orbit: int = 1
     bipolar: bool = True

--- a/pySC/apps/response.py
+++ b/pySC/apps/response.py
@@ -62,7 +62,7 @@ class ResponseData(BaseModel):
     timestamp: Optional[float] = None
     original_save_path: Optional[str] = None
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     @property
     def not_normalized_response_matrix(self):
@@ -84,7 +84,7 @@ class ResponseData(BaseModel):
         return filename
 
 
-class ResponseMeasurement(BaseModel):
+class ResponseMeasurement(BaseModel, extra="forbid"):
     inputs_delta: Union[float, list[float]]
     shots_per_orbit: int = 1
     bipolar: bool = True

--- a/pySC/apps/response_matrix.py
+++ b/pySC/apps/response_matrix.py
@@ -68,7 +68,7 @@ class ResponseMatrix(BaseModel):
     _inverse_RM_H: Optional[InverseResponseMatrix] = PrivateAttr(default=None)
     _inverse_RM_V: Optional[InverseResponseMatrix] = PrivateAttr(default=None)
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     @property
     def RM(self):

--- a/pySC/core/rng.py
+++ b/pySC/core/rng.py
@@ -3,7 +3,7 @@ from typing import Union, Optional
 from numpy.random import default_rng
 import numpy as np
 
-class RNG(BaseModel):
+class RNG(BaseModel, extra="forbid"):
     seed: int
     rng_state: Optional[dict[str, Union[str, int, dict[str, int]]]] = None
     default_truncation: Optional[float] = None

--- a/pySC/core/supports.py
+++ b/pySC/core/supports.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-class ElementOffset(BaseModel):
+class ElementOffset(BaseModel, extra="forbid"):
     """
     Element offset: represents an element in the support system with its misalignments.
     """
@@ -30,7 +30,7 @@ class ElementOffset(BaseModel):
     s: Optional[float] = None  # s position in the ring, to be filled later
 
 
-class SupportEndpoint(BaseModel):
+class SupportEndpoint(BaseModel, extra="forbid"):
     """
     Support endpoint: represents an endpoint of a support structure.
     """
@@ -41,7 +41,7 @@ class SupportEndpoint(BaseModel):
     s: Optional[float] = None  # s position in the ring, to be filled later
 
 
-class Support(BaseModel):
+class Support(BaseModel, extra="forbid"):
     """Support structure: represents a support with two endpoints."""
     start: SupportEndpoint
     end: SupportEndpoint
@@ -69,7 +69,7 @@ class Support(BaseModel):
         return f'({self.name}: {self.start.index}-{self.end.index})'
 
 
-class SupportSystem(BaseModel):
+class SupportSystem(BaseModel, extra="forbid"):
     '''
     Support system: handles all misalignments through a graph-like structure.
     It is composed in level of supports, where L0 is the level of elements (offsets),

--- a/pySC/core/types.py
+++ b/pySC/core/types.py
@@ -8,7 +8,7 @@ NPARRAY = Annotated[np.ndarray,
                     PlainSerializer(lambda x: x.tolist(), return_type=list)
                    ]
 
-class BaseModelWithSave(BaseModel):
+class BaseModelWithSave(BaseModel, extra="forbid"):
     def save_as(self, filename: Union[Path, str], indent: Optional[int] = None) -> None:
         if type(filename) is not Path:
             filename = Path(filename)

--- a/pySC/tuning/c_minus.py
+++ b/pySC/tuning/c_minus.py
@@ -49,7 +49,7 @@ class CMinus(BaseModel, extra="forbid"):
         matrix[1] = delta_c_minus.imag
 
         c_minus_response_matrix = ResponseMatrix(matrix=matrix,
-                                                 outputs_plane=['SQ'] * len(self.controls)
+                                                 output_planes=['SQ'] * len(self.controls)
                                                 )
         inverse_matrix = c_minus_response_matrix.build_pseudoinverse().matrix
         c_minus_real_knob = inverse_matrix[:, 0]


### PR DESCRIPTION
## Summary

- Add `extra="forbid"` to the 14 remaining Pydantic models that were using the default `extra="ignore"`
- Fix a silent data-loss bug in `BBAAnalysis` where `total_rejections` was passed to the constructor but silently discarded
- Clean up a deprecated kwarg usage in `c_minus.py`

## Why

Pydantic's default behavior (`extra="ignore"`) silently discards unknown keyword arguments. This is dangerous in a scientific simulation codebase — a typo or renamed field means data is silently lost with no error.

We already had 23 of 38 models using `extra="forbid"`, but the remaining 15 were inconsistent. This inconsistency already caused a real bug: `BBAAnalysis(total_rejections=sum(~mask_accepted))` at `bba.py:431` was passing a value that was silently thrown away, meaning the `total_rejections` count was never stored on the analysis result.

With `extra="forbid"` on all models, any unknown kwarg immediately raises a `ValidationError`, making this class of bug impossible.

## What changed

1. **Bug fix:** Added `total_rejections: int = 0` field to `BBAAnalysis` (was being passed but silently discarded)
2. **Cleanup:** Updated `outputs_plane=` → `output_planes=` in `c_minus.py` (deprecated kwarg)
3. **14 models:** Added `extra="forbid"` via class kwarg or `ConfigDict`

`AbstractInterface` is intentionally excluded — it's subclassed by external repos.

## Deserialization safety

`ResponseMatrix` is the only model serialized to JSON. Its `@model_validator(mode='before')` renames deprecated keys (`inputs_plane` → `input_planes`) before Pydantic's extra-field check runs, so old JSON files deserialize correctly.

## Test plan

- [x] All modified modules import without error
- [x] `BBAAnalysis` constructor accepts `total_rejections`
- [x] Unknown kwargs raise `ValidationError` on any modified model
- [x] Deprecated `ResponseMatrix` kwargs still work via before-validator