### PR TITLE
Hotfix: allow mapping when defining tune controls

### DIFF
--- a/pySC/__init__.py
+++ b/pySC/__init__.py
@@ -6,7 +6,7 @@ pySC
 
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 from .core.simulated_commissioning import SimulatedCommissioning
 from .configuration.generation import generate_SC

--- a/pySC/configuration/tuning_conf.py
+++ b/pySC/configuration/tuning_conf.py
@@ -62,8 +62,9 @@ def configure_tuning(SC: SimulatedCommissioning) -> None:
         assert 'controls_2' in tune_conf, 'controls_2 missing from tune configuration.'
 
         control_1_conf = tune_conf['controls_1']
-        assert 'regex' in control_1_conf, 'regex is missing from controls_1 in tune configuration.'
         assert 'component' in control_1_conf, 'component is missing from controls_1 in tune configuration.'
+        if 'regex' not in control_1_conf or 'mapping' not in control_1_conf:
+            raise Exception(f'regex or mapping should be defined for tune/controls_1')
         component = control_1_conf['component']
         _, names = get_indices_and_names(SC, 'tune/controls_1', control_1_conf)
         controls_1 = [name + '/' + component for name in names]
@@ -73,7 +74,8 @@ def configure_tuning(SC: SimulatedCommissioning) -> None:
 
         control_2_conf = tune_conf['controls_2']
         assert 'component' in control_2_conf, 'component is missing from controls_2 in tune configuration.'
-        assert 'regex' in control_2_conf, 'regex is missing from controls_1 in tune configuration.'
+        if 'regex' not in control_2_conf or 'mapping' not in control_2_conf:
+            raise Exception(f'regex or mapping should be defined for tune/controls_2')
         component = control_2_conf['component']
         _, names = get_indices_and_names(SC, 'tune/controls_2', control_2_conf)
         controls_2 = [name + '/' + component for name in names]


### PR DESCRIPTION
Allow mapping when defining tune controls