### PR TITLE
Sextupole bba

### DIFF
--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, PrivateAttr, ConfigDict
-from typing import Optional, ClassVar
+from pydantic import BaseModel, PrivateAttr, ConfigDict, model_validator
+from typing import Optional, ClassVar, Literal
 import datetime
 import logging
 import numpy as np
@@ -9,7 +9,9 @@ from .codes import BBACode
 from ..utils.file_tools import dict_to_h5
 from .tools import get_average_orbit
 from .interface import AbstractInterface
-from ..core.types import NPARRAY
+from ..core.types import NPARRAY, MagnetType
+
+BBA_MagnetType = Literal[MagnetType.norm_quad, MagnetType.skew_quad, MagnetType.norm_sext]
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +29,7 @@ class BBAData(BaseModel, extra="forbid"):
     n0: int  # Number of steps in the corrector strength
     shots_per_orbit: int
     bipolar: bool = True
-    skew_quad: bool = False
+    magnet_type: BBA_MagnetType = MagnetType.norm_quad
     bpm_number: int
 
     initial_k0l: Optional[float] = None
@@ -48,6 +50,14 @@ class BBAData(BaseModel, extra="forbid"):
     raw_bpm_y_up_err: list[list[float]] = []
     raw_bpm_x_down_err: list[list[float]] = []
     raw_bpm_y_down_err: list[list[float]] = []
+
+    @property
+    def skew_quad(self):
+        logger.warning("Deprecation: skew_quad should not be used, instead check if magnet_type is MagnetType.skew_quad.")
+        if self.magnet_type is MagnetType.skew_quad:
+            return True
+        else:
+            return False
 
     def save(self, folder_to_save: Optional[Path] = None) -> Path:
         if folder_to_save is None:
@@ -99,6 +109,7 @@ class BBA_Measurement(BaseModel, extra="forbid"):
     bpm_number: int
     shots_per_orbit: int = 2
     bipolar: bool = True
+    magnet_type: BBA_MagnetType = MagnetType.norm_quad
     quad_is_skew: bool = False
     plane: str = None
 
@@ -111,6 +122,17 @@ class BBA_Measurement(BaseModel, extra="forbid"):
 
     _interface: Optional[AbstractInterface] = PrivateAttr(default=None) # to be set at generation of measurement
 
+    @model_validator(mode='before')
+    def check_deprecations(cls, data):
+        if 'quad_is_skew' in data.keys():
+            logger.warning('DEPRECATION: `quad_is_skew` in BBA_Measurement has been deprecated. Please speicify `magnet_type`.')
+            if data['quad_is_skew']:
+                data['magnet_type'] = MagnetType.skew_quad
+            else:
+                data['magnet_type'] = MagnetType.norm_quad
+            del data['magnet_type']
+        return data
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Initialize BBAData instances for horizontal and vertical procedures
@@ -118,12 +140,12 @@ class BBA_Measurement(BaseModel, extra="forbid"):
             self.H_data = BBAData(plane='H', bpm=self.bpm, quadrupole=self.quadrupole, bpm_number=self.bpm_number,
                                   corrector=self.h_corrector, dk0l=self.dk0l_x, dk1l=self.dk1l_x,
                                   n0=self.n0, shots_per_orbit=self.shots_per_orbit, bipolar=self.bipolar,
-                                  skew_quad=self.quad_is_skew)
+                                  magnet_type=self.magnet_type)
         if self.v_corrector is not None:
             self.V_data = BBAData(plane='V', bpm=self.bpm, quadrupole=self.quadrupole, bpm_number=self.bpm_number,
                                   corrector=self.v_corrector, dk0l=self.dk0l_y, dk1l=self.dk1l_y,
                                   n0=self.n0, shots_per_orbit=self.shots_per_orbit, bipolar=self.bipolar,
-                                  skew_quad=self.quad_is_skew)
+                                  magnet_type=self.magnet_type)
 
 
     def print_init(self):
@@ -141,6 +163,7 @@ class BBA_Measurement(BaseModel, extra="forbid"):
         logger.debug(f"    Initial V. k0l = {self.initial_v_k0l*1e6:.1f} urad")
         logger.debug(f"    Initial k1l = {self.initial_k1l:.3f} 1/m")
         logger.debug(f"    Bipolar = {self.bipolar}")
+        logger.debug(f"    Magnet type = {self.magnet_type.value}")
         logger.debug("")
 
     def one_plane_loop(self, plane: str):
@@ -310,16 +333,20 @@ def prep_ios(data: BBAData, n_downstream: Optional[int] = None):
     for ii in range(data.n0):
         if data.plane == 'H':
             bpm_position[ii] = np.mean(all_x[:, ii, bpm_number - start])
-            if data.skew_quad:
+            if data.magnet_type in [MagnetType.skew_quad]:
                 induced_orbit_shift[ii] = np.polyfit(k1_arr, all_y[:,ii], 1)[0] * data.dk1l
-            else:
+            elif data.magnet_type in [MagnetType.norm_quad, MagnetType.norm_sext]:
                 induced_orbit_shift[ii] = np.polyfit(k1_arr, all_x[:,ii], 1)[0] * data.dk1l
+            else:
+                raise Exception(f"Unknown magnet type {data.magnet_type}.")
         else:
             bpm_position[ii] = np.mean(all_y[:, ii, bpm_number - start])
-            if data.skew_quad:
+            if data.magnet_type in [MagnetType.skew_quad, MagnetType.norm_sext]:
                 induced_orbit_shift[ii] = np.polyfit(k1_arr, all_x[:,ii], 1)[0] * data.dk1l
-            else:
+            elif data.magnet_type in [MagnetType.norm_quad]:
                 induced_orbit_shift[ii] = np.polyfit(k1_arr, all_y[:,ii], 1)[0] * data.dk1l
+            else:
+                raise Exception(f"Unknown magnet type {data.magnet_type}.")
     return bpm_position, induced_orbit_shift
 
 def reject_bpm_outlier(induced_orbit_shift: np.ndarray, bpm_outlier_sigma: float) -> np.ndarray[bool]:
@@ -346,10 +373,14 @@ class BBAAnalysis(BaseModel):
     offset: float
     offset_error: float
 
+    quadratics: NPARRAY
     slopes: NPARRAY
+    intercepts: NPARRAY
     centers: NPARRAY
 
+    quadratics_err: NPARRAY
     slopes_err: NPARRAY
+    intercepts_err: NPARRAY
     centers_err: NPARRAY
 
     induced_orbit_shift: NPARRAY
@@ -389,22 +420,67 @@ class BBAAnalysis(BaseModel):
 
         bpm_position, induced_orbit_shift = prep_ios(data=data, n_downstream=n_downstream)
 
-        p, pcov = np.polyfit(bpm_position, induced_orbit_shift, 1, cov=True)
-        slopes = p[0]
-        centers = - p[1] / p[0]
-        slopes_err = np.sqrt(pcov[0,0])
-        centers_err = np.sqrt(centers ** 2 * (pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1]))
+        nanmask = ~np.isnan(bpm_position)
 
-        mask_bpm_outlier = reject_bpm_outlier(induced_orbit_shift, bpm_outlier_sigma)
-        mask_slopes = reject_slopes(slopes, slope_cutoff)
-        mask_center = reject_center_outlier(centers, center_cutoff)
-        mask_accepted = np.logical_and(np.logical_and(mask_bpm_outlier, mask_slopes), mask_center)
+        assert sum(nanmask), 'BBA fit: all bpm readings are nan'
 
-        # calculate offset as a weighted average of the centers, with weights equal to the absolute slope
-        cc = centers[mask_accepted]
-        ww = np.abs(slopes[mask_accepted])
-        cc_err = centers_err[mask_accepted]
-        ww_err = slopes_err[mask_accepted]
+        if data.magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+            order = 1
+        elif data.magnet_type in [MagnetType.norm_sext]:
+            order = 2
+        else:
+            raise NotImplementedError(f"Unknown magnet type {data.magnet_type}.")
+
+        p, pcov = np.polyfit(bpm_position[nanmask], induced_orbit_shift[nanmask], order, cov=True)
+
+
+        if data.magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+            quadratics = None
+            quadratics_err = None
+            slopes = p[0]
+            centers = - p[1] / p[0]
+            slopes_err = np.sqrt(pcov[0,0])
+            centers_err = np.sqrt(centers ** 2 * (pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1]))
+            intercepts = p[1]
+            intercepts_err = np.sqrt(pcov[1,1])
+
+            mask_bpm_outlier = reject_bpm_outlier(induced_orbit_shift, bpm_outlier_sigma)
+            mask_slopes = reject_slopes(slopes, slope_cutoff)
+            mask_center = reject_center_outlier(centers, center_cutoff)
+            mask_accepted = np.logical_and(np.logical_and(mask_bpm_outlier, mask_slopes), mask_center)
+
+            # calculate offset as a weighted average of the centers, with weights equal to the absolute slope
+            cc = centers[mask_accepted]
+            ww = np.abs(slopes[mask_accepted])
+            cc_err = centers_err[mask_accepted]
+            ww_err = slopes_err[mask_accepted]
+        elif data.magnet_type in [MagnetType.norm_sext]:
+            # solve quadratic equation for minimum
+            # a x ** 2 + b * x + c = 0 => x = - b / 2a
+            # a -> quadratics
+            # b -> slopes
+            # c -> intercepts
+
+            quadratics = p[0]
+            centers = - 0.5 * (p[1] / p[0]) 
+            quadratics_err = np.sqrt(pcov[0,0])
+            centers_err = 0.5 * np.sqrt(centers ** 2 * (pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1]))
+
+            slopes = p[1]
+            slopes_err = np.sqrt(pcov[1,1])
+            intercepts = p[2]
+            intercepts_err = np.sqrt(pcov[2,2])
+
+            mask_bpm_outlier = reject_bpm_outlier(induced_orbit_shift, bpm_outlier_sigma)
+            mask_slopes = reject_slopes(quadratics, slope_cutoff)
+            mask_center = reject_center_outlier(centers, center_cutoff)
+            mask_accepted = np.logical_and(np.logical_and(mask_bpm_outlier, mask_slopes), mask_center)
+
+            # calculate offset as a weighted average of the centers, with weights equal to the absolute quadratic term
+            cc = centers[mask_accepted]
+            ww = np.abs(quadratics[mask_accepted])
+            cc_err = centers_err[mask_accepted]
+            ww_err = quadratics_err[mask_accepted]
 
         CS = np.sum(ww * cc)
         S = np.sum(ww) 
@@ -412,16 +488,20 @@ class BBAAnalysis(BaseModel):
         VCS = np.sum(cc**2 * ww_err**2 + ww**2 * cc_err**2) # variance of CS
         VO = ( VCS / CS**2 + VS / S**2) # (variance of offset) / offset**2
 
-        offset = CS / S # offset = CS / S, average of centers with abs(slopes) as weights
+        offset = CS / S # offset = CS / S, average of centers with abs(slopes) or abs(quadratics) as weights
         offset_error = offset * np.sqrt(VO)
 
         result = BBAAnalysis(
                              offset=offset,
                              offset_error=offset_error,
-                             slopes=slopes,
+                             quadratics=quadratics,
                              centers=centers,
-                             slopes_err=slopes_err,
+                             slopes=slopes,
+                             intercepts=intercepts,
+                             quadratics_err=quadratics_err,
                              centers_err=centers_err,
+                             slopes_err=slopes_err,
+                             intercepts_err=intercepts_err,
                              induced_orbit_shift=induced_orbit_shift,
                              bpm_position=bpm_position,
                              mask_accepted=mask_accepted,

--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -390,6 +390,8 @@ class BBAAnalysis(BaseModel):
 
     n_downstream: Optional[int]
 
+    fit_order:int
+
     rejected_outliers: int
     rejected_slopes: int
     rejected_centers: int
@@ -425,13 +427,13 @@ class BBAAnalysis(BaseModel):
         assert sum(nanmask), 'BBA fit: all bpm readings are nan'
 
         if data.magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
-            order = 1
+            fit_order = 1
         elif data.magnet_type in [MagnetType.norm_sext]:
-            order = 2
+            fit_order = 2
         else:
             raise NotImplementedError(f"Unknown magnet type {data.magnet_type}.")
 
-        p, pcov = np.polyfit(bpm_position[nanmask], induced_orbit_shift[nanmask], order, cov=True)
+        p, pcov = np.polyfit(bpm_position[nanmask], induced_orbit_shift[nanmask], fit_order, cov=True)
 
 
         if data.magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
@@ -502,6 +504,7 @@ class BBAAnalysis(BaseModel):
                              centers_err=centers_err,
                              slopes_err=slopes_err,
                              intercepts_err=intercepts_err,
+                             fit_order=fit_order,
                              induced_orbit_shift=induced_orbit_shift,
                              bpm_position=bpm_position,
                              mask_accepted=mask_accepted,

--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -464,7 +464,7 @@ class BBAAnalysis(BaseModel):
             # c -> intercepts
 
             quadratics = p[0]
-            centers = - 0.5 * (p[1] / p[0]) 
+            centers = - 0.5 * (p[1] / p[0])
             quadratics_err = np.sqrt(pcov[0,0])
             centers_err = np.abs(centers) * np.sqrt(pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1])
 

--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -491,7 +491,7 @@ class BBAAnalysis(BaseModel):
         VO = ( VCS / CS**2 + VS / S**2) # (variance of offset) / offset**2
 
         offset = CS / S # offset = CS / S, average of centers with abs(slopes) or abs(quadratics) as weights
-        offset_error = offset * np.sqrt(VO)
+        offset_error = np.abs(offset) * np.sqrt(VO)
 
         result = BBAAnalysis(
                              offset=offset,

--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -442,7 +442,7 @@ class BBAAnalysis(BaseModel):
             slopes = p[0]
             centers = - p[1] / p[0]
             slopes_err = np.sqrt(pcov[0,0])
-            centers_err = np.sqrt(centers ** 2 * (pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1]))
+            centers_err = np.abs(centers) * np.sqrt(pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1])
             intercepts = p[1]
             intercepts_err = np.sqrt(pcov[1,1])
 
@@ -466,7 +466,7 @@ class BBAAnalysis(BaseModel):
             quadratics = p[0]
             centers = - 0.5 * (p[1] / p[0]) 
             quadratics_err = np.sqrt(pcov[0,0])
-            centers_err = 0.5 * np.sqrt(centers ** 2 * (pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1]))
+            centers_err = np.abs(centers) * np.sqrt(pcov[0,0] / p[0]**2 + pcov[1,1] / p[1] ** 2 - 2 * pcov[0, 1] / p[0] / p[1])
 
             slopes = p[1]
             slopes_err = np.sqrt(pcov[1,1])

--- a/pySC/apps/bba.py
+++ b/pySC/apps/bba.py
@@ -130,7 +130,7 @@ class BBA_Measurement(BaseModel, extra="forbid"):
                 data['magnet_type'] = MagnetType.skew_quad
             else:
                 data['magnet_type'] = MagnetType.norm_quad
-            del data['magnet_type']
+            del data['quad_is_skew']
         return data
 
     def __init__(self, **kwargs):

--- a/pySC/apps/measurements.py
+++ b/pySC/apps/measurements.py
@@ -73,9 +73,15 @@ def measure_bba(interface: AbstractInterface, bpm_name, config: dict, shots_per_
         assert folder_to_save.exists(), f'Path {folder_to_save.resolve()} does not exist.'
         assert folder_to_save.is_dir(), f'Path {folder_to_save.resolve()} is not a directory.'
 
-    keys = config.keys()
-    for word in ['QUAD', 'HCORR', 'HCORR_delta', 'QUAD_dk_H', 'VCORR', 'VCORR_delta', 'QUAD_dk_V', 'QUAD_is_skew', 'number']:
-        assert word in keys, f'{word} is not in configuration.'
+    if 'QUAD_is_skew' in config:
+        logger.warning('DEPRECATION: QUAD_is_skew in BBA config should no longer be used!')
+        if config['QUAD_is_skew']:
+            config['magnet_type'] = "skew_quadrupole"
+        else:
+            config['magnet_type'] = "normal_quadrupole"
+
+    for word in ['QUAD', 'HCORR', 'HCORR_delta', 'QUAD_dk_H', 'VCORR', 'VCORR_delta', 'QUAD_dk_V', 'magnet_type', 'number']:
+        assert word in config, f'{word} is not in configuration.'
 
     measurement = BBA_Measurement(bpm=bpm_name,
                                   quadrupole=config['QUAD'],
@@ -85,7 +91,7 @@ def measure_bba(interface: AbstractInterface, bpm_name, config: dict, shots_per_
                                   dk1l_x=config['QUAD_dk_H'],
                                   dk0l_y=config['VCORR_delta'],
                                   dk1l_y=config['QUAD_dk_V'],
-                                  quad_is_skew=config['QUAD_is_skew'],
+                                  magnet_type=config['magnet_type'],
                                   n0=n_corr_steps,
                                   bpm_number=config['number'],
                                   shots_per_orbit=shots_per_orbit,

--- a/pySC/configuration/bpm_system_conf.py
+++ b/pySC/configuration/bpm_system_conf.py
@@ -2,7 +2,6 @@ import numpy as np
 import logging
 
 from ..core.simulated_commissioning import SimulatedCommissioning
-from ..core.bpm_system import BPM_FIELDS_TO_INITIALISE_ZEROS, BPM_FIELDS_TO_INITIALISE_ONES
 from .general import get_error, get_indices_and_names
 from .supports_conf import generate_element_misalignments
 
@@ -87,11 +86,7 @@ def configure_bpms(SC: SimulatedCommissioning) -> None:
     SC.bpm_system.noise_tbt_x = np.array(bpms_tbt_noise)
     SC.bpm_system.noise_tbt_y = np.array(bpms_tbt_noise)
 
-    nbpm = len(bpms_indices)
-    for field in BPM_FIELDS_TO_INITIALISE_ZEROS:
-        setattr(SC.bpm_system, field, np.zeros(nbpm, dtype=float))
-    for field in BPM_FIELDS_TO_INITIALISE_ONES:
-        setattr(SC.bpm_system, field, np.ones(nbpm, dtype=float))
+    SC.bpm_system.initialize_empty_arrays()
 
     for index, bpm_category in zip(bpms_indices, bpms_categories):
         generate_element_misalignments(SC, index, bpms_conf[bpm_category])

--- a/pySC/configuration/bpm_system_conf.py
+++ b/pySC/configuration/bpm_system_conf.py
@@ -2,6 +2,7 @@ import numpy as np
 import logging
 
 from ..core.simulated_commissioning import SimulatedCommissioning
+from ..core.bpm_system import BPM_FIELDS_TO_INITIALISE_ZEROS, BPM_FIELDS_TO_INITIALISE_ONES
 from .general import get_error, get_indices_and_names
 from .supports_conf import generate_element_misalignments
 
@@ -86,7 +87,11 @@ def configure_bpms(SC: SimulatedCommissioning) -> None:
     SC.bpm_system.noise_tbt_x = np.array(bpms_tbt_noise)
     SC.bpm_system.noise_tbt_y = np.array(bpms_tbt_noise)
 
-    SC.bpm_system.initialize_empty_arrays()
+    nbpm = len(bpms_indices)
+    for field in BPM_FIELDS_TO_INITIALISE_ZEROS:
+        setattr(SC.bpm_system, field, np.zeros(nbpm, dtype=float))
+    for field in BPM_FIELDS_TO_INITIALISE_ONES:
+        setattr(SC.bpm_system, field, np.ones(nbpm, dtype=float))
 
     for index, bpm_category in zip(bpms_indices, bpms_categories):
         generate_element_misalignments(SC, index, bpms_conf[bpm_category])

--- a/pySC/core/control.py
+++ b/pySC/core/control.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from pydantic import BaseModel, PrivateAttr, PositiveInt
 from typing import Optional, Literal, Union, TYPE_CHECKING
 import logging
-from .types import BaseModelWithSave
+from .types import BaseModelWithSave, MagnetType
 
 if TYPE_CHECKING:
     from .magnet import ControlMagnetLink
@@ -21,6 +21,10 @@ class IndivControl(BaseModel, extra="forbid"):
     component: Literal["A", "B"]
     order: PositiveInt
     is_integrated: bool
+
+    @property
+    def magnet_type(self) -> MagnetType:
+        return MagnetType.from_component_order(component=self.component, order=self.order)
 
 class KnobControl(BaseModel, extra="forbid"):
     control_names: list[str]

--- a/pySC/core/types.py
+++ b/pySC/core/types.py
@@ -1,5 +1,6 @@
-from pydantic import BeforeValidator, PlainSerializer, BaseModel
-from typing import Annotated, Union, Optional
+from enum import StrEnum
+from pydantic import BeforeValidator, PlainSerializer, BaseModel, PositiveInt
+from typing import Annotated, Union, Optional, Literal, Self
 import numpy as np
 from pathlib import Path
 
@@ -25,3 +26,31 @@ class BaseModelWithSave(BaseModel, extra="forbid"):
             else:
                 raise Exception(f'Unknown file extension: {suffix}.')
         return
+
+class MagnetType(StrEnum):
+    norm_dip = "normal_dipole"
+    skew_dip = "skew_dipole"
+    norm_quad = "normal_quadrupole"
+    skew_quad = "skew_quadrupole"
+    norm_sext = "normal_sextupole"
+    norm_octu = "normal_octupole"
+    undefined = "undefined"
+
+    @classmethod
+    def from_component_order(cls, component: Literal["A", "B"], order: PositiveInt) -> Self:
+        if component == "B":
+            if order == 1:
+                return MagnetType.norm_dip
+            elif order == 2:
+                return MagnetType.norm_quad
+            elif order == 3:
+                return MagnetType.norm_sext
+            elif order == 4:
+                return MagnetType.norm_octu
+        elif component == "A":
+            if order == 1:
+                return MagnetType.skew_dip
+            if order == 2:
+                return MagnetType.skew_quad
+
+        return MagnetType.undefined

--- a/pySC/tuning/orbit_bba.py
+++ b/pySC/tuning/orbit_bba.py
@@ -7,6 +7,7 @@ from ..core.control import IndivControl
 from .pySC_interface import pySCOrbitInterface
 from ..apps import measure_bba
 from ..apps.bba import BBAAnalysis
+from ..core.types import MagnetType
 
 logger = logging.getLogger(__name__)
 
@@ -30,15 +31,33 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
     config: Dict = dict()
 
     @classmethod
-    def generate_config(cls, SC: "SimulatedCommissioning", max_dx_at_bpm = 1e-3,
-                        max_modulation=20e-6):
+    def generate_config(cls, SC: "SimulatedCommissioning",
+                        max_dx_at_bpm=1e-3,
+                        max_modulation=20e-6,
+                        max_dx_at_bpm_sextupole=None,
+                        max_modulation_sextupole=None,
+                        ignore_sextupoles: bool = False):
+
+        if max_modulation_sextupole is None:
+            max_modulation_sextupole = max_modulation
+        if max_dx_at_bpm_sextupole is None:
+            max_dx_at_bpm_sextupole = max_dx_at_bpm
 
         config = {}
         RM_name = 'orbit'
         SC.tuning.fetch_response_matrix(RM_name, orbit=True)
         RM = SC.tuning.response_matrix[RM_name]
 
-        bba_magnets = SC.tuning.bba_magnets
+        all_bba_magnets = SC.tuning.bba_magnets
+        if ignore_sextupoles:
+            bba_magnets = []
+            for control in all_bba_magnets:
+                info = SC.magnet_settings.controls[control].info 
+                if not ( info.component == "B" and info.order == 3 ):
+                    bba_magnets.append(control)
+        else:
+            bba_magnets = all_bba_magnets
+
         bba_magnets_s = get_mag_s_pos(SC, bba_magnets)
 
         mask_H = np.array(RM.input_planes) == 'H'
@@ -64,9 +83,17 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
             bba_magnet_is_integrated = bba_magnet_info.is_integrated
             bba_magnet_index = SC.magnet_settings.magnets[bba_magnet_info.magnet_name].sim_index
             if bba_magnet_info.component == 'B':
-                quad_is_skew = False
+                if bba_magnet_info.order == 2:
+                    magnet_type = MagnetType.norm_quad
+                elif bba_magnet_info.order == 3:
+                    magnet_type = MagnetType.norm_sext
+                else:
+                    raise NotImplementedError("BBA configuration for {bba_magnet_info.component}{bba_magnet_info.order} magnets not implemented.")
             else: # it is a skew quadrupole component
-                quad_is_skew = True
+                if bba_magnet_info.order == 2:
+                    magnet_type = MagnetType.skew_quad
+                else:
+                    raise NotImplementedError("BBA configuration for {bba_magnet_info.component}{bba_magnet_info.order} magnets not implemented.")
 
             max_H_response = -1
             the_HCORR_number = -1
@@ -77,11 +104,15 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
                 the_HCORR_number = int(imax)
             hcorr_delta = max_dx_at_bpm/max_H_response
 
-            if not quad_is_skew:
+            if magnet_type is MagnetType.norm_quad:
                 quad_response = np.sqrt(betx_at_bpms * betx[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qx)))
-            else: # it is a skew quadrupole component
+                quad_dkl_h = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+            elif magnet_type is MagnetType.skew_quad:
                 quad_response = np.sqrt(bety_at_bpms * bety[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qy)))
-            quad_dkl_h = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+                quad_dkl_h = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+            elif magnet_type is MagnetType.norm_sext:
+                sext_response = np.sqrt(betx_at_bpms * betx[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qx)))
+                quad_dkl_h = 2 * (max_modulation_sextupole / float(np.max(np.abs(sext_response)))) / max_dx_at_bpm_sextupole**2
 
             max_V_response = -1
             the_VCORR_number = -1
@@ -92,11 +123,17 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
                 the_VCORR_number = int(imax)
             vcorr_delta = max_dx_at_bpm/max_V_response
 
-            if not quad_is_skew:
+            if magnet_type is MagnetType.norm_quad:
                 quad_response = np.sqrt(bety_at_bpms * bety[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qy)))
-            else: # it is a skew quadrupole component
+                quad_dkl_v = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+            elif magnet_type is MagnetType.skew_quad:
                 quad_response = np.sqrt(betx_at_bpms * betx[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qx)))
-            quad_dkl_v = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+                quad_dkl_v = (max_modulation / float(np.max(np.abs(quad_response)))) / max_dx_at_bpm
+            elif magnet_type is MagnetType.norm_sext:
+                # sext_response = np.sqrt(betx_at_bpms * betx[bba_magnet_index]) / (2 * np.abs(np.sin(np.pi*qx)))
+                # quad_dkl_v = 2 * (max_modulation_sextupole / float(np.max(np.abs(sext_response)))) / max_dx_at_bpm_sextupole**2
+                # dk for sextupole bba is actually the same whether horizontal or vertical alignment.
+                quad_dkl_v = quad_dkl_h
 
             if not bba_magnet_is_integrated:
                 bba_magnet_length = SC.magnet_settings.magnets[bba_magnet_info.magnet_name].length
@@ -118,7 +155,7 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
                                 'QUAD_dk_H': quad_dk_h,
                                 'VCORR_delta': vcorr_delta,
                                 'QUAD_dk_V': quad_dk_v,
-                                'QUAD_is_skew': quad_is_skew,
+                                'magnet_type': magnet_type.value,
                                }
 
         return Orbit_BBA_Configuration(config=config)
@@ -152,7 +189,7 @@ def orbit_bba(SC: "SimulatedCommissioning", bpm_name: str, n_corr_steps: int = 7
         offset = analysis_result.offset
         offset_error = analysis_result.offset_error
     except Exception as exc:
-        print(exc)
+        logger.warning(f"Exception | {type(exc).__name__}: {exc}")
         logger.warning(f'Failed to compute trajectory BBA for BPM {bpm_name}')
         offset, offset_error = 0, np.nan
 

--- a/pySC/tuning/orbit_bba.py
+++ b/pySC/tuning/orbit_bba.py
@@ -53,7 +53,8 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
             bba_magnets = []
             for control in all_bba_magnets:
                 info = SC.magnet_settings.controls[control].info 
-                if not ( info.component == "B" and info.order == 3 ):
+                assert type(info) is IndivControl, f'BBA magnet of unsupported type: {type(info)}'
+                if info.magnet_type is not MagnetType.norm_sext:
                     bba_magnets.append(control)
         else:
             bba_magnets = all_bba_magnets

--- a/pySC/tuning/orbit_bba.py
+++ b/pySC/tuning/orbit_bba.py
@@ -59,6 +59,7 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
         else:
             bba_magnets = all_bba_magnets
 
+        assert len(bba_magnets) > 0, "No BBA magnets available after applying ignore_sextupoles filter."
         bba_magnets_s = get_mag_s_pos(SC, bba_magnets)
 
         mask_H = np.array(RM.input_planes) == 'H'

--- a/pySC/tuning/orbit_bba.py
+++ b/pySC/tuning/orbit_bba.py
@@ -52,7 +52,7 @@ class Orbit_BBA_Configuration(BaseModel, extra="forbid"):
         if ignore_sextupoles:
             bba_magnets = []
             for control in all_bba_magnets:
-                info = SC.magnet_settings.controls[control].info 
+                info = SC.magnet_settings.controls[control].info
                 assert type(info) is IndivControl, f'BBA magnet of unsupported type: {type(info)}'
                 if info.magnet_type is not MagnetType.norm_sext:
                     bba_magnets.append(control)

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
-from typing import TYPE_CHECKING, Dict, Literal
+from typing import TYPE_CHECKING, Dict, Literal, Optional
 import numpy as np
 import logging
 from ..apps import measure_bba
 from ..apps.bba import BBAAnalysis
+from ..core.control import IndivControl
+from ..core.types import MagnetType
 from .pySC_interface import pySCInjectionInterface
 from .orbit_bba import get_mag_s_pos
 
@@ -16,10 +18,19 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
     config: Dict = dict()
 
     @classmethod
-    def generate_config(cls, SC: "SimulatedCommissioning", max_dx_at_bpm = 1e-3,
-                        max_modulation=200e-6, n_shots=1, max_ncorr_index=10,
-                        n_downstream_bpms=50):
- #                       max_modulation=600e-6, max_dx_at_bpm=1.5e-3
+    def generate_config(cls, SC: "SimulatedCommissioning",
+                        max_dx_at_bpm: float = 1e-3,
+                        max_modulation: float = 200e-6,
+                        max_ncorr_index: int = 10,
+                        n_downstream_bpms: int = 50,
+                        max_dx_at_bpm_sextupole: Optional[float] = None,
+                        max_modulation_sextupole: Optional[float] = None,
+                        ignore_sextupoles: bool = False):
+
+        if max_modulation_sextupole is None:
+            max_modulation_sextupole = max_modulation
+        if max_dx_at_bpm_sextupole is None:
+            max_dx_at_bpm_sextupole = max_dx_at_bpm
 
         config = {}
         n_turns = 1
@@ -27,7 +38,16 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
         SC.tuning.fetch_response_matrix(RM_name, orbit=False, n_turns=n_turns)
         RM = SC.tuning.response_matrix[RM_name]
 
-        bba_magnets = SC.tuning.bba_magnets
+        all_bba_magnets = SC.tuning.bba_magnets
+        if ignore_sextupoles:
+            bba_magnets = []
+            for control in all_bba_magnets:
+                info = SC.magnet_settings.controls[control].info 
+                if not ( info.component == "B" and info.order == 3 ):
+                    bba_magnets.append(control)
+        else:
+            bba_magnets = all_bba_magnets
+
         bba_magnets_s = get_mag_s_pos(SC, bba_magnets)
 
         #d1, d2 = RM.RM.shape
@@ -36,12 +56,34 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
         HRM = RM.matrix[:nbpm, :nh]
         VRM = RM.matrix[nbpm:, nh:]
 
+        betx = SC.lattice.twiss['betx']
+        bety = SC.lattice.twiss['bety']
+        mux = SC.lattice.twiss['mux']
+        muy = SC.lattice.twiss['muy']
+
         for bpm_number in range(len(SC.bpm_system.indices)):
             bpm_index = SC.bpm_system.indices[bpm_number]
             bpm_s = SC.lattice.twiss['s'][bpm_index]
 
             bba_magnet_number = np.argmin(np.abs(bba_magnets_s - bpm_s))
             the_bba_magnet = bba_magnets[bba_magnet_number]
+
+            bba_magnet_info = SC.magnet_settings.controls[the_bba_magnet].info
+            assert type(bba_magnet_info) is IndivControl, f'BBA magnet of unsupported type: {type(bba_magnet_info)}'
+            bba_magnet_is_integrated = bba_magnet_info.is_integrated
+            bba_magnet_index = SC.magnet_settings.magnets[bba_magnet_info.magnet_name].sim_index
+            if bba_magnet_info.component == 'B':
+                if bba_magnet_info.order == 2:
+                    magnet_type = MagnetType.norm_quad
+                elif bba_magnet_info.order == 3:
+                    magnet_type = MagnetType.norm_sext
+                else:
+                    raise NotImplementedError("BBA configuration for {bba_magnet_info.component}{bba_magnet_info.order} magnets not implemented.")
+            else: # it is a skew quadrupole component
+                if bba_magnet_info.order == 2:
+                    magnet_type = MagnetType.skew_quad
+                else:
+                    raise NotImplementedError("BBA configuration for {bba_magnet_info.component}{bba_magnet_info.order} magnets not implemented.")
 
             HCORR_s = np.array(get_mag_s_pos(SC, SC.tuning.HCORR))
             HCORR_numbers = list(np.where(HCORR_s < bpm_s)[0])
@@ -64,21 +106,49 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
                 logger.warning(f'WARNING: zero H response for BPM {SC.bpm_system.names[bpm_number]}!')
                 hcorr_delta = 0
             else:
-                hcorr_delta = max_dx_at_bpm/max_H_response
+                if magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+                    hcorr_delta = max_dx_at_bpm/max_H_response
+                elif magnet_type is MagnetType.norm_sext:
+                    hcorr_delta = max_dx_at_bpm_sextupole/max_H_response
 
-            if the_bba_magnet.split('/')[-1][0] == 'B':
-                temp_RM = HRM[bpm_number:bpm_number+n_downstream_bpms, the_HCORR_number]
-            else: # it is a skew quadrupole component
-                ## TODO: this is wrong if hcorr and vcorr are not the same magnets!!
-                temp_RM = VRM[bpm_number:bpm_number+n_downstream_bpms, the_HCORR_number]
+            downstream_bpm_indices = SC.bpm_system.indices[bpm_number:bpm_number+n_downstream_bpms]
 
-            max_response = float(np.max(np.abs(temp_RM)))
+            target_betx = betx[downstream_bpm_indices]
+            target_bety = bety[downstream_bpm_indices]
+            target_mux = mux[downstream_bpm_indices]
+            target_muy = muy[downstream_bpm_indices]
+
+            source_betx = betx[bba_magnet_index]
+            source_bety = bety[bba_magnet_index]
+            source_mux = mux[bba_magnet_index]
+            source_muy = muy[bba_magnet_index]
+
+            # make response zero in bpms upstream of bba magnet by setting equal phase advances
+            target_mux[target_mux < source_mux] = source_mux 
+            target_muy[target_muy < source_muy] = source_muy 
+
+            # sign depends on several things but we take absolute value later, so we ignore it here
+            bba_magnet_response_x = np.sqrt(target_betx * source_betx) * np.sin(2*np.pi*(target_mux - source_mux))
+            bba_magnet_response_y = np.sqrt(target_bety * source_bety) * np.sin(2*np.pi*(target_muy - source_muy))
+
+            if magnet_type is MagnetType.norm_quad: 
+                max_response = float(np.max(np.abs(bba_magnet_response_x)))
+            elif magnet_type is MagnetType.skew_quad:
+                max_response = float(np.max(np.abs(bba_magnet_response_y)))
+            elif magnet_type is MagnetType.norm_sext:
+                max_response = float(np.max(np.abs(bba_magnet_response_x)))
+
             if max_response < 1e-10:
                 logger.warning(f'WARNING: very small response for BPM {SC.bpm_system.names[bpm_number]} from magnet {the_bba_magnet} and HCORR {SC.tuning.HCORR[the_HCORR_number]}')
-                quad_dk_h = 0
+                quad_dkl_h = 0
                 hcorr_delta = 0
             else:
-                quad_dk_h = (max_modulation/max_response) / max_dx_at_bpm
+                if magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+                    quad_dkl_h = (max_modulation/max_response) / max_dx_at_bpm
+                elif magnet_type is MagnetType.norm_sext:
+                    quad_dkl_h = 2*(max_modulation_sextupole/max_response) / max_dx_at_bpm_sextupole**2
+
+
 
             max_V_response = -1
             the_VCORR_number = -1
@@ -91,22 +161,35 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
                 logger.warning(f'WARNING: zero V response for BPM {SC.bpm_system.names[bpm_number]}!')
                 vcorr_delta = 0
             else:
-                vcorr_delta = max_dx_at_bpm/max_V_response
+                if magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+                    vcorr_delta = max_dx_at_bpm/max_V_response
+                elif magnet_type is MagnetType.norm_sext:
+                    vcorr_delta = max_dx_at_bpm_sextupole/max_V_response
 
-            if the_bba_magnet.split('/')[-1][0] == 'B':
-                temp_RM = VRM[bpm_number:bpm_number+n_downstream_bpms, the_VCORR_number]
-                quad_is_skew = False
-            else: # it is a skew quadrupole component
-                ## TODO: this is wrong if hcorr and vcorr are not the same magnets!!
-                temp_RM = HRM[bpm_number:bpm_number+n_downstream_bpms, the_VCORR_number]
-                quad_is_skew = True
-            max_response = float(np.max(np.abs(temp_RM)))
+            if magnet_type is MagnetType.norm_quad: 
+                max_response = float(np.max(np.abs(bba_magnet_response_y)))
+            elif magnet_type is MagnetType.skew_quad:
+                max_response = float(np.max(np.abs(bba_magnet_response_x)))
+            elif magnet_type is MagnetType.norm_sext:
+                max_response = float(np.max(np.abs(bba_magnet_response_x)))
+
             if max_response < 1e-10:
                 logger.warning(f'WARNING: very small response for BPM {SC.bpm_system.names[bpm_number]} from magnet {the_bba_magnet} and HCORR {SC.tuning.VCORR[the_VCORR_number]}')
-                quad_dk_v = 0
+                quad_dkl_v = 0
                 vcorr_delta = 0
             else:
-                quad_dk_v = (max_modulation/max_response) / max_dx_at_bpm
+                if magnet_type in [MagnetType.norm_quad, MagnetType.skew_quad]:
+                    quad_dkl_v = (max_modulation/max_response) / max_dx_at_bpm
+                elif magnet_type is MagnetType.norm_sext:
+                    quad_dkl_v = 2*(max_modulation_sextupole/max_response) / max_dx_at_bpm_sextupole**2
+
+            if not bba_magnet_is_integrated:
+                bba_magnet_length = SC.magnet_settings.magnets[bba_magnet_info.magnet_name].length
+                quad_dk_h = quad_dkl_h / bba_magnet_length
+                quad_dk_v = quad_dkl_v / bba_magnet_length
+            else:
+                quad_dk_h = quad_dkl_h
+                quad_dk_v = quad_dkl_v
 
             bpm_name = SC.bpm_system.names[bpm_number]
             config[bpm_name] = {'index': bpm_index,
@@ -120,7 +203,7 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
                                 'QUAD_dk_H': quad_dk_h,
                                 'VCORR_delta': vcorr_delta,
                                 'QUAD_dk_V': quad_dk_v,
-                                'QUAD_is_skew': quad_is_skew,
+                                'magnet_type': magnet_type.value,
                                }
 
         return Trajectory_BBA_Configuration(config=config)
@@ -154,7 +237,7 @@ def trajectory_bba(SC: "SimulatedCommissioning", bpm_name: str, n_corr_steps: in
         offset = analysis_result.offset
         offset_error = analysis_result.offset_error
     except Exception as exc:
-        print(exc)
+        logger.warning(f"Exception | {type(exc).__name__}: {exc}")
         logger.warning(f'Failed to compute trajectory BBA for BPM {bpm_name}')
         offset, offset_error = 0, np.nan
 

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -42,8 +42,10 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
         if ignore_sextupoles:
             bba_magnets = []
             for control in all_bba_magnets:
-                info = SC.magnet_settings.controls[control].info 
-                if not ( info.component == "B" and info.order == 3 ):
+                info = SC.magnet_settings.controls[control].info
+                assert type(info) is IndivControl, f'BBA magnet of unsupported type: {type(info)}'
+                magnet_type = info.magnet_type
+                if magnet_type is MagnetType.norm_sext:
                     bba_magnets.append(control)
         else:
             bba_magnets = all_bba_magnets

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -2,28 +2,15 @@ from pydantic import BaseModel
 from typing import TYPE_CHECKING, Dict, Literal
 import numpy as np
 import logging
-from ..core.control import IndivControl
 from ..apps import measure_bba
 from ..apps.bba import BBAAnalysis
 from .pySC_interface import pySCInjectionInterface
+from .orbit_bba import get_mag_s_pos
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..core.simulated_commissioning import SimulatedCommissioning
-
-def get_mag_s_pos(SC: "SimulatedCommissioning", MAG: list[str]):
-    s_list = []
-    for control_name in MAG:
-        control = SC.magnet_settings.controls[control_name]
-        if type(control.info) is IndivControl:
-            magnet_name = control.info.magnet_name
-        else:
-            raise NotImplementedError(f"{control} is of type {type(control.info).__name__} which is not implemented.")
-        index = SC.magnet_settings.magnets[magnet_name].sim_index
-        s_pos = SC.lattice.twiss['s'][index]
-        s_list.append(s_pos)
-    return s_list
 
 class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
     config: Dict = dict()

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -132,7 +132,7 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
             bba_magnet_response_x = np.sqrt(target_betx * source_betx) * np.sin(2*np.pi*(target_mux - source_mux))
             bba_magnet_response_y = np.sqrt(target_bety * source_bety) * np.sin(2*np.pi*(target_muy - source_muy))
 
-            if magnet_type is MagnetType.norm_quad: 
+            if magnet_type is MagnetType.norm_quad:
                 max_response = float(np.max(np.abs(bba_magnet_response_x)))
             elif magnet_type is MagnetType.skew_quad:
                 max_response = float(np.max(np.abs(bba_magnet_response_y)))
@@ -167,7 +167,7 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
                 elif magnet_type is MagnetType.norm_sext:
                     vcorr_delta = max_dx_at_bpm_sextupole/max_V_response
 
-            if magnet_type is MagnetType.norm_quad: 
+            if magnet_type is MagnetType.norm_quad:
                 max_response = float(np.max(np.abs(bba_magnet_response_y)))
             elif magnet_type is MagnetType.skew_quad:
                 max_response = float(np.max(np.abs(bba_magnet_response_x)))

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -49,6 +49,7 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
         else:
             bba_magnets = all_bba_magnets
 
+        assert len(bba_magnets) > 0, "No BBA magnets available after applying ignore_sextupoles filter."
         bba_magnets_s = get_mag_s_pos(SC, bba_magnets)
 
         #d1, d2 = RM.RM.shape

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -44,8 +44,7 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
             for control in all_bba_magnets:
                 info = SC.magnet_settings.controls[control].info
                 assert type(info) is IndivControl, f'BBA magnet of unsupported type: {type(info)}'
-                magnet_type = info.magnet_type
-                if magnet_type is MagnetType.norm_sext:
+                if info.magnet_type is not MagnetType.norm_sext:
                     bba_magnets.append(control)
         else:
             bba_magnets = all_bba_magnets

--- a/pySC/tuning/trajectory_bba.py
+++ b/pySC/tuning/trajectory_bba.py
@@ -125,8 +125,8 @@ class Trajectory_BBA_Configuration(BaseModel, extra="forbid"):
             source_muy = muy[bba_magnet_index]
 
             # make response zero in bpms upstream of bba magnet by setting equal phase advances
-            target_mux[target_mux < source_mux] = source_mux 
-            target_muy[target_muy < source_muy] = source_muy 
+            target_mux[target_mux < source_mux] = source_mux
+            target_muy[target_muy < source_muy] = source_muy
 
             # sign depends on several things but we take absolute value later, so we ignore it here
             bba_magnet_response_x = np.sqrt(target_betx * source_betx) * np.sin(2*np.pi*(target_mux - source_mux))

--- a/pySC/tuning/tuning_core.py
+++ b/pySC/tuning/tuning_core.py
@@ -284,12 +284,14 @@ class Tuning(BaseModel, extra="forbid"):
             setpoint = self._parent.design_magnet_settings.get(control_name)
             self._parent.magnet_settings.set(control_name, setpoint)
 
-    def generate_trajectory_bba_config(self, max_dx_at_bpm: float = 1e-3, 
+    def generate_trajectory_bba_config(self, max_dx_at_bpm: float = 1e-3,
                                        max_modulation: float = 0.2e-3,
-                                       n_downstream_bpms: int = 50, 
+                                       n_downstream_bpms: int = 50,
                                        max_ncorr_index: int = 10,
                                        max_modulation_sextupole: Optional[float] = None,
-                                       max_dx_at_bpm_sextupole: Optional[float] = None) -> None:
+                                       max_dx_at_bpm_sextupole: Optional[float] = None,
+                                       ignore_sextupoles: bool = False,
+                                      ) -> None:
         config = Trajectory_BBA_Configuration.generate_config(SC=self._parent,
                                                               max_dx_at_bpm=max_dx_at_bpm,
                                                               max_modulation=max_modulation,
@@ -297,15 +299,20 @@ class Tuning(BaseModel, extra="forbid"):
                                                               max_ncorr_index=max_ncorr_index,
                                                               max_dx_at_bpm_sextupole=max_dx_at_bpm_sextupole,
                                                               max_modulation_sextupole=max_modulation_sextupole,
+                                                              ignore_sextupoles=ignore_sextupoles,
                                                               )
         self.trajectory_bba_config = config
         return
 
-    def generate_orbit_bba_config(self, max_dx_at_bpm: float = 0.3e-3, 
-                                       max_modulation: float = 20e-6) -> None:
+    def generate_orbit_bba_config(self, max_dx_at_bpm: float = 0.3e-3,
+                                  max_modulation: float = 20e-6,
+                                  ignore_sextupoles: bool = False,
+                                 ) -> None:
         config = Orbit_BBA_Configuration.generate_config(SC=self._parent,
                                                          max_dx_at_bpm=max_dx_at_bpm,
-                                                         max_modulation=max_modulation)
+                                                         max_modulation=max_modulation,
+                                                         ignore_sextupoles=ignore_sextupoles,
+                                                        )
         self.orbit_bba_config = config
         return
 

--- a/pySC/tuning/tuning_core.py
+++ b/pySC/tuning/tuning_core.py
@@ -287,12 +287,17 @@ class Tuning(BaseModel, extra="forbid"):
     def generate_trajectory_bba_config(self, max_dx_at_bpm: float = 1e-3, 
                                        max_modulation: float = 0.2e-3,
                                        n_downstream_bpms: int = 50, 
-                                       max_ncorr_index: int = 10) -> None:
+                                       max_ncorr_index: int = 10,
+                                       max_modulation_sextupole: Optional[float] = None,
+                                       max_dx_at_bpm_sextupole: Optional[float] = None) -> None:
         config = Trajectory_BBA_Configuration.generate_config(SC=self._parent,
                                                               max_dx_at_bpm=max_dx_at_bpm,
                                                               max_modulation=max_modulation,
                                                               n_downstream_bpms=n_downstream_bpms,
-                                                              max_ncorr_index=max_ncorr_index)
+                                                              max_ncorr_index=max_ncorr_index,
+                                                              max_dx_at_bpm_sextupole=max_dx_at_bpm_sextupole,
+                                                              max_modulation_sextupole=max_modulation_sextupole,
+                                                              )
         self.trajectory_bba_config = config
         return
 

--- a/pySC/tuning/tuning_core.py
+++ b/pySC/tuning/tuning_core.py
@@ -304,13 +304,18 @@ class Tuning(BaseModel, extra="forbid"):
         self.trajectory_bba_config = config
         return
 
-    def generate_orbit_bba_config(self, max_dx_at_bpm: float = 0.3e-3,
+    def generate_orbit_bba_config(self,
+                                  max_dx_at_bpm: float = 0.3e-3,
                                   max_modulation: float = 20e-6,
+                                  max_dx_at_bpm_sextupole: Optional[float] = None,
+                                  max_modulation_sextupole: Optional[float] = None,
                                   ignore_sextupoles: bool = False,
                                  ) -> None:
         config = Orbit_BBA_Configuration.generate_config(SC=self._parent,
                                                          max_dx_at_bpm=max_dx_at_bpm,
                                                          max_modulation=max_modulation,
+                                                         max_dx_at_bpm_sextupole=max_dx_at_bpm_sextupole,
+                                                         max_modulation_sextupole=max_modulation_sextupole,
                                                          ignore_sextupoles=ignore_sextupoles,
                                                         )
         self.orbit_bba_config = config

--- a/tests/apps/test_bba.py
+++ b/tests/apps/test_bba.py
@@ -14,6 +14,7 @@ from pySC.apps.bba import (
     reject_center_outlier,
 )
 from pySC.apps.codes import BBACode
+from pySC.core.types import MagnetType
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +78,56 @@ def _make_bba_data(n0=7, n_bpms=10, bpm_number=3, plane='H', bipolar=True,
         data.raw_bpm_y_up_err.append(list(np.zeros(n_bpms)))
         data.raw_bpm_x_down_err.append(list(np.zeros(n_bpms)))
         data.raw_bpm_y_down_err.append(list(np.zeros(n_bpms)))
+
+    return data
+
+
+def _make_sextupole_bba_data(n0=9, n_bpms=10, bpm_number=3, plane='H',
+                             dk0l=1e-4, dk1l=0.05, offset=0.0):
+    """Build synthetic normal-sextupole BBA data with a known quadratic center."""
+    data = BBAData(
+        quadrupole='S1', bpm='BPM3', corrector='CH1', plane=plane,
+        dk0l=dk0l, dk1l=dk1l, n0=n0, shots_per_orbit=1, bipolar=True,
+        magnet_type=MagnetType.norm_sext, bpm_number=bpm_number,
+    )
+
+    positions = np.linspace(-dk0l, dk0l, n0) + offset
+    rng = np.random.default_rng(456)
+    response = np.abs(1.0 + 0.3 * rng.standard_normal(n_bpms))
+    other_plane_response = np.abs(0.7 + 0.2 * rng.standard_normal(n_bpms))
+
+    for position in positions:
+        x_center = np.zeros(n_bpms)
+        y_center = np.zeros(n_bpms)
+        if plane == 'H':
+            x_center[bpm_number] = position
+            ios = response * (position - offset) ** 2
+            x_up = x_center + ios
+            x_down = x_center - ios
+            y_up = y_center.copy()
+            y_down = y_center.copy()
+        else:
+            y_center[bpm_number] = position
+            ios = response * (position - offset) ** 2
+            x_up = x_center + ios
+            x_down = x_center - ios
+            y_up = y_center + other_plane_response * position
+            y_down = y_center - other_plane_response * position
+
+        data.raw_bpm_x_center.append(list(x_center))
+        data.raw_bpm_y_center.append(list(y_center))
+        data.raw_bpm_x_up.append(list(x_up))
+        data.raw_bpm_y_up.append(list(y_up))
+        data.raw_bpm_x_down.append(list(x_down))
+        data.raw_bpm_y_down.append(list(y_down))
+
+        zeros = list(np.zeros(n_bpms))
+        data.raw_bpm_x_center_err.append(zeros)
+        data.raw_bpm_y_center_err.append(zeros)
+        data.raw_bpm_x_up_err.append(zeros)
+        data.raw_bpm_y_up_err.append(zeros)
+        data.raw_bpm_x_down_err.append(zeros)
+        data.raw_bpm_y_down_err.append(zeros)
 
     return data
 
@@ -208,6 +259,29 @@ class TestBBAAnalysis:
         assert np.isfinite(result.offset_error)
         assert result.offset_error >= 0
 
+    def test_bba_analysis_error_is_nonnegative_for_negative_offset(self):
+        """Error propagation reports a nonnegative uncertainty."""
+        data = _make_bba_data(n0=9, n_bpms=10, bpm_number=3,
+                              offset=-0.001, bipolar=True)
+
+        result = BBAAnalysis.analyze(data)
+        assert result.offset < 0
+        assert np.isfinite(result.offset_error)
+        assert result.offset_error >= 0
+
+    @pytest.mark.parametrize("plane", ["H", "V"])
+    def test_bba_analysis_normal_sextupole_known_offset(self, plane):
+        """Normal sextupole analysis fits a quadratic and recovers its center."""
+        offset = 0.002 if plane == "H" else -0.0015
+        data = _make_sextupole_bba_data(plane=plane, offset=offset)
+
+        result = BBAAnalysis.analyze(data)
+
+        assert result.fit_order == 2
+        np.testing.assert_allclose(result.offset, offset, atol=1e-9)
+        assert np.isfinite(result.offset_error)
+        assert result.offset_error >= 0
+
     @pytest.mark.regression
     def test_bba_analysis_total_rejections_stored(self):
         """BBAAnalysis.analyze() stores total_rejections correctly.
@@ -332,3 +406,23 @@ class TestBBAMeasurement:
         assert BBACode.HYSTERESIS_DONE not in codes
         assert BBACode.HORIZONTAL in codes
         assert codes[-1] == BBACode.DONE
+
+    def test_quad_is_skew_deprecated_argument_sets_magnet_type(self):
+        """Deprecated quad_is_skew input remains backward compatible."""
+        meas = BBA_Measurement(
+            bpm='BPM3',
+            quadrupole='Q1',
+            h_corrector='CH1',
+            v_corrector=None,
+            dk0l_x=1e-4,
+            dk1l_x=0.05,
+            dk0l_y=1e-4,
+            dk1l_y=0.05,
+            n0=3,
+            bpm_number=3,
+            shots_per_orbit=1,
+            quad_is_skew=True,
+        )
+
+        assert meas.magnet_type is MagnetType.skew_quad
+        assert meas.H_data.magnet_type is MagnetType.skew_quad

--- a/tests/apps/test_measurements.py
+++ b/tests/apps/test_measurements.py
@@ -122,6 +122,31 @@ class TestMeasureBBA:
         with pytest.raises(AssertionError):
             list(measure_bba(iface, 'BPM0', bad_config, skip_save=True))
 
+    def test_accepts_magnet_type_config(self, mock_interface):
+        """New BBA config format uses magnet_type instead of QUAD_is_skew."""
+        iface = mock_interface(n_bpms=5)
+        config = _bba_config()
+        del config['QUAD_is_skew']
+        config['magnet_type'] = 'normal_sextupole'
+
+        results = list(measure_bba(iface, 'BPM0', config, skip_save=True))
+
+        _, measurement = results[-1]
+        assert measurement.magnet_type == 'normal_sextupole'
+        assert measurement.H_data.magnet_type == 'normal_sextupole'
+
+    def test_deprecated_quad_is_skew_config_sets_magnet_type(self, mock_interface):
+        """Old QUAD_is_skew config remains backward compatible."""
+        iface = mock_interface(n_bpms=5)
+        config = _bba_config()
+        config['QUAD_is_skew'] = True
+
+        results = list(measure_bba(iface, 'BPM0', config, skip_save=True))
+
+        _, measurement = results[-1]
+        assert measurement.magnet_type == 'skew_quadrupole'
+        assert measurement.H_data.magnet_type == 'skew_quadrupole'
+
 
 # ---------------------------------------------------------------------------
 # measure_ORM tests

--- a/tests/core/test_control.py
+++ b/tests/core/test_control.py
@@ -2,6 +2,7 @@
 import pytest
 
 from pySC.core.control import Control, IndivControl, KnobControl, KnobData, LinearConv
+from pySC.core.types import MagnetType
 
 
 # ---------- LinearConv ----------
@@ -51,6 +52,11 @@ def test_indiv_control_creation():
     assert ic.component == "B"
     assert ic.order == 2
     assert ic.is_integrated is True
+
+
+def test_indiv_control_magnet_type():
+    ic = IndivControl(magnet_name="SF1", component="B", order=3, is_integrated=False)
+    assert ic.magnet_type is MagnetType.norm_sext
 
 
 # ---------- KnobControl ----------

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 from pydantic import ConfigDict
 
-from pySC.core.types import NPARRAY, BaseModelWithSave
+from pySC.core.types import NPARRAY, BaseModelWithSave, MagnetType
 
 
 class ArrayModel(BaseModelWithSave):
@@ -91,3 +91,24 @@ def test_save_as_unknown_suffix_raises(tmp_path):
     path = tmp_path / "test.xyz"
     with pytest.raises(Exception, match="Unknown file extension"):
         m.save_as(path)
+
+
+# ---------- MagnetType ----------
+
+@pytest.mark.parametrize(
+    ("component", "order", "expected"),
+    [
+        ("B", 1, MagnetType.norm_dip),
+        ("A", 1, MagnetType.skew_dip),
+        ("B", 2, MagnetType.norm_quad),
+        ("A", 2, MagnetType.skew_quad),
+        ("B", 3, MagnetType.norm_sext),
+        ("B", 4, MagnetType.norm_octu),
+    ],
+)
+def test_magnet_type_from_component_order(component, order, expected):
+    assert MagnetType.from_component_order(component=component, order=order) is expected
+
+
+def test_magnet_type_from_component_order_unknown():
+    assert MagnetType.from_component_order(component="A", order=3) is MagnetType.undefined

--- a/tests/tuning/test_orbit_bba.py
+++ b/tests/tuning/test_orbit_bba.py
@@ -1,7 +1,10 @@
 """Tests for pySC.tuning.orbit_bba: orbit beam-based alignment."""
 import pytest
 import numpy as np
+from types import SimpleNamespace
 
+from pySC.apps.response_matrix import ResponseMatrix
+from pySC.core.control import IndivControl
 from pySC.tuning.orbit_bba import (
     Orbit_BBA_Configuration,
     orbit_bba,
@@ -40,6 +43,158 @@ def test_generate_orbit_bba_config(sc_with_orbit_rm):
         assert 'VCORR' in entry
         assert 'QUAD_dk_H' in entry
         assert 'QUAD_dk_V' in entry
+
+
+def _sextupole_b3_controls(sc):
+    """Return normal sextupole controls registered on the test SC."""
+    return [
+        name for name, control in sc.magnet_settings.controls.items()
+        if control.info.component == "B" and control.info.order == 3
+    ]
+
+
+def _make_mock_orbit_config_sc(bba_magnets):
+    """Create a minimal SC-like object for deterministic orbit BBA config tests."""
+    controls = {
+        "q1/B2": SimpleNamespace(info=IndivControl(magnet_name="q1", component="B", order=2, is_integrated=False)),
+        "s1/B3": SimpleNamespace(info=IndivControl(magnet_name="s1", component="B", order=3, is_integrated=False)),
+        "ch1/B1": SimpleNamespace(info=IndivControl(magnet_name="ch1", component="B", order=1, is_integrated=True)),
+        "ch2/B1": SimpleNamespace(info=IndivControl(magnet_name="ch2", component="B", order=1, is_integrated=True)),
+        "cv1/A1": SimpleNamespace(info=IndivControl(magnet_name="cv1", component="A", order=1, is_integrated=True)),
+        "cv2/A1": SimpleNamespace(info=IndivControl(magnet_name="cv2", component="A", order=1, is_integrated=True)),
+    }
+    magnets = {
+        "q1": SimpleNamespace(sim_index=1, length=0.5),
+        "s1": SimpleNamespace(sim_index=2, length=0.4),
+        "ch1": SimpleNamespace(sim_index=0, length=0.1),
+        "ch2": SimpleNamespace(sim_index=2, length=0.1),
+        "cv1": SimpleNamespace(sim_index=0, length=0.1),
+        "cv2": SimpleNamespace(sim_index=2, length=0.1),
+    }
+    matrix = np.array([
+        [1.0, 0.5, 0.0, 0.0],
+        [0.7, 1.2, 0.0, 0.0],
+        [0.0, 0.0, 1.1, 0.6],
+        [0.0, 0.0, 0.8, 1.3],
+    ])
+    response_matrix = ResponseMatrix(
+        matrix=matrix,
+        input_names=["ch1/B1", "ch2/B1", "cv1/A1", "cv2/A1"],
+        output_names=["bpm1", "bpm2", "bpm1", "bpm2"],
+        input_planes=["H", "H", "V", "V"],
+        output_planes=["H", "H", "V", "V"],
+    )
+    tuning = SimpleNamespace(
+        bba_magnets=bba_magnets,
+        HCORR=["ch1/B1", "ch2/B1"],
+        VCORR=["cv1/A1", "cv2/A1"],
+        response_matrix={"orbit": response_matrix},
+        fetch_response_matrix=lambda *args, **kwargs: None,
+    )
+    return SimpleNamespace(
+        tuning=tuning,
+        magnet_settings=SimpleNamespace(controls=controls, magnets=magnets),
+        bpm_system=SimpleNamespace(indices=[3, 4], names=["bpm1", "bpm2"]),
+        lattice=SimpleNamespace(twiss={
+            "s": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+            "betx": np.ones(5),
+            "bety": np.ones(5),
+            "qx": 0.31,
+            "qy": 0.32,
+        }),
+    )
+
+
+def test_generate_orbit_bba_config_sextupole_unit():
+    """Orbit BBA config supports normal sextupole BBA magnets."""
+    sc = _make_mock_orbit_config_sc(["s1/B3"])
+
+    config = Orbit_BBA_Configuration.generate_config(
+        SC=sc,
+        max_dx_at_bpm=0.3e-3,
+        max_modulation=20e-6,
+        max_dx_at_bpm_sextupole=1e-3,
+        max_modulation_sextupole=10e-6,
+    )
+
+    assert {entry["magnet_type"] for entry in config.config.values()} == {"normal_sextupole"}
+    for entry in config.config.values():
+        assert entry["QUAD"] == "s1/B3"
+        assert np.isfinite(entry["QUAD_dk_H"])
+        assert np.isfinite(entry["QUAD_dk_V"])
+
+
+def test_generate_orbit_bba_config_ignore_sextupoles_unit():
+    """ignore_sextupoles removes normal sextupole BBA magnets."""
+    sc = _make_mock_orbit_config_sc(["s1/B3", "q1/B2"])
+
+    config = Orbit_BBA_Configuration.generate_config(SC=sc, ignore_sextupoles=True)
+
+    assert {entry["QUAD"] for entry in config.config.values()} == {"q1/B2"}
+    assert "normal_sextupole" not in {entry["magnet_type"] for entry in config.config.values()}
+
+
+def test_generate_orbit_bba_config_empty_filter_unit():
+    """ignore_sextupoles fails clearly when all BBA magnets are sextupoles."""
+    sc = _make_mock_orbit_config_sc(["s1/B3"])
+
+    with pytest.raises(AssertionError, match="No BBA magnets available"):
+        Orbit_BBA_Configuration.generate_config(SC=sc, ignore_sextupoles=True)
+
+
+@pytest.mark.xfail(reason="HMBA single-cell ring has near-zero response in some BPM/corrector pairs")
+def test_generate_orbit_bba_config_supports_sextupole_magnets(sc_with_orbit_rm):
+    """Orbit BBA config labels normal sextupole BBA magnets."""
+    sc = sc_with_orbit_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc)
+
+        config = Orbit_BBA_Configuration.generate_config(
+            SC=sc,
+            max_dx_at_bpm=0.3e-3,
+            max_modulation=20e-6,
+            max_dx_at_bpm_sextupole=1e-3,
+            max_modulation_sextupole=10e-6,
+        )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
+
+    assert {entry["magnet_type"] for entry in config.config.values()} == {"normal_sextupole"}
+
+
+@pytest.mark.xfail(reason="HMBA single-cell ring has near-zero response in some BPM/corrector pairs")
+def test_generate_orbit_bba_config_ignore_sextupoles(sc_with_orbit_rm):
+    """ignore_sextupoles removes normal sextupole BBA magnets from config selection."""
+    sc = sc_with_orbit_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc) + original_bba_magnets
+
+        config = Orbit_BBA_Configuration.generate_config(
+            SC=sc,
+            ignore_sextupoles=True,
+        )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
+
+    assert "normal_sextupole" not in {entry["magnet_type"] for entry in config.config.values()}
+
+
+def test_generate_orbit_bba_config_raises_when_filter_leaves_no_magnets(sc_with_orbit_rm):
+    """ignore_sextupoles fails clearly when only sextupole BBA magnets exist."""
+    sc = sc_with_orbit_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc)
+
+        with pytest.raises(AssertionError, match="No BBA magnets available"):
+            Orbit_BBA_Configuration.generate_config(
+                SC=sc,
+                ignore_sextupoles=True,
+            )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
 
 
 @pytest.mark.xfail(reason="HMBA single-cell ring has near-zero response in some BPM/corrector pairs")

--- a/tests/tuning/test_trajectory_bba.py
+++ b/tests/tuning/test_trajectory_bba.py
@@ -41,6 +41,74 @@ def test_generate_trajectory_bba_config(sc_with_traj_rm):
         assert 'VCORR' in entry
 
 
+def _sextupole_b3_controls(sc):
+    """Return normal sextupole controls registered on the test SC."""
+    return [
+        name for name, control in sc.magnet_settings.controls.items()
+        if control.info.component == "B" and control.info.order == 3
+    ]
+
+
+def test_generate_trajectory_bba_config_supports_sextupole_magnets(sc_with_traj_rm):
+    """Trajectory BBA config labels normal sextupole BBA magnets."""
+    sc = sc_with_traj_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc)
+
+        config = Trajectory_BBA_Configuration.generate_config(
+            SC=sc,
+            max_dx_at_bpm=1e-3,
+            max_modulation=0.2e-3,
+            max_dx_at_bpm_sextupole=2e-3,
+            max_modulation_sextupole=0.1e-3,
+            n_downstream_bpms=3,
+            max_ncorr_index=10,
+        )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
+
+    assert len(config.config) == len(sc.bpm_system.names)
+    assert {entry["magnet_type"] for entry in config.config.values()} == {"normal_sextupole"}
+
+
+def test_generate_trajectory_bba_config_ignore_sextupoles(sc_with_traj_rm):
+    """ignore_sextupoles removes normal sextupole BBA magnets from config selection."""
+    sc = sc_with_traj_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc) + original_bba_magnets
+
+        config = Trajectory_BBA_Configuration.generate_config(
+            SC=sc,
+            ignore_sextupoles=True,
+            n_downstream_bpms=3,
+            max_ncorr_index=10,
+        )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
+
+    assert "normal_sextupole" not in {entry["magnet_type"] for entry in config.config.values()}
+
+
+def test_generate_trajectory_bba_config_raises_when_filter_leaves_no_magnets(sc_with_traj_rm):
+    """ignore_sextupoles fails clearly when only sextupole BBA magnets exist."""
+    sc = sc_with_traj_rm
+    original_bba_magnets = sc.tuning.bba_magnets
+    try:
+        sc.tuning.bba_magnets = _sextupole_b3_controls(sc)
+
+        with pytest.raises(AssertionError, match="No BBA magnets available"):
+            Trajectory_BBA_Configuration.generate_config(
+                SC=sc,
+                ignore_sextupoles=True,
+                n_downstream_bpms=3,
+                max_ncorr_index=10,
+            )
+    finally:
+        sc.tuning.bba_magnets = original_bba_magnets
+
+
 @pytest.mark.xfail(reason="HMBA single-cell ring lacks sufficient BPMs downstream for trajectory BBA")
 def test_trajectory_bba_single_bpm(sc_with_traj_rm):
     """trajectory_bba runs without error on a single BPM."""

--- a/tests/tuning/test_tuning_core.py
+++ b/tests/tuning/test_tuning_core.py
@@ -209,6 +209,70 @@ def test_set_multipole_scale_warns_and_skips_empty_overlap(caplog):
     SC.magnet_settings.set.assert_not_called()
 
 
+def test_generate_trajectory_bba_config_forwards_sextupole_options():
+    """Tuning wrapper forwards trajectory sextupole BBA options."""
+    tuning = Tuning()
+    SC = MagicMock()
+    tuning._parent = SC
+    config = MagicMock()
+
+    with patch(
+        "pySC.tuning.tuning_core.Trajectory_BBA_Configuration.generate_config",
+        return_value=config,
+    ) as generate_config:
+        tuning.generate_trajectory_bba_config(
+            max_dx_at_bpm=1e-3,
+            max_modulation=2e-4,
+            n_downstream_bpms=7,
+            max_ncorr_index=3,
+            max_dx_at_bpm_sextupole=2e-3,
+            max_modulation_sextupole=1e-4,
+            ignore_sextupoles=True,
+        )
+
+    generate_config.assert_called_once_with(
+        SC=SC,
+        max_dx_at_bpm=1e-3,
+        max_modulation=2e-4,
+        n_downstream_bpms=7,
+        max_ncorr_index=3,
+        max_dx_at_bpm_sextupole=2e-3,
+        max_modulation_sextupole=1e-4,
+        ignore_sextupoles=True,
+    )
+    assert tuning.trajectory_bba_config is config
+
+
+def test_generate_orbit_bba_config_forwards_sextupole_options():
+    """Tuning wrapper forwards orbit sextupole BBA options."""
+    tuning = Tuning()
+    SC = MagicMock()
+    tuning._parent = SC
+    config = MagicMock()
+
+    with patch(
+        "pySC.tuning.tuning_core.Orbit_BBA_Configuration.generate_config",
+        return_value=config,
+    ) as generate_config:
+        tuning.generate_orbit_bba_config(
+            max_dx_at_bpm=3e-4,
+            max_modulation=2e-5,
+            max_dx_at_bpm_sextupole=1e-3,
+            max_modulation_sextupole=1e-5,
+            ignore_sextupoles=True,
+        )
+
+    generate_config.assert_called_once_with(
+        SC=SC,
+        max_dx_at_bpm=3e-4,
+        max_modulation=2e-5,
+        max_dx_at_bpm_sextupole=1e-3,
+        max_modulation_sextupole=1e-5,
+        ignore_sextupoles=True,
+    )
+    assert tuning.orbit_bba_config is config
+
+
 # ---------------------------------------------------------------------------
 # Integration tests (require configured SC)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Implements BBA with a sextupolar field component of a magnet.
- Adds a MagnetType enum, to be used during runtime to check if a magnet is normal or skew quad or sextupole etc.
- Configuration of trajectory-based BBA more robust by using analytical "first-order" trajectory response matrix.
- Changes in config for a BBA measurement, to generalize also for sextupoles