### PR TITLE
Nonlinear improvements

### DIFF
--- a/pySC/core/lattice.py
+++ b/pySC/core/lattice.py
@@ -244,14 +244,15 @@ class ATLattice(Lattice):
                  'dpx': elemdata.dispersion[:, 1],
                  'dy' : elemdata.dispersion[:, 2],
                  'dpy': elemdata.dispersion[:, 3],
-                 'wx_chrom': elemdata.w[:, 0],
+                 'wx_chrom': elemdata.W[:, 0],
                  'bx_chrom': elemdata.dbeta[:, 0]/elemdata.beta[:, 0],
                  'ax_chrom': elemdata.dalpha[:, 0] - (elemdata.alpha[:, 0] / elemdata.beta[:, 0]) * elemdata.dbeta[:, 0],
-                 'wy_chrom': elemdata.w[:, 1],
+                 'wy_chrom': elemdata.W[:, 1],
                  'by_chrom': elemdata.dbeta[:, 1]/elemdata.beta[:, 1],
                  'ay_chrom': elemdata.dalpha[:, 1] - (elemdata.alpha[:, 1] / elemdata.beta[:, 1]) * elemdata.dbeta[:, 1],
                  'dmux': elemdata.dmu[:, 0] / twopi,
                  'dmuy': elemdata.dmu[:, 1] / twopi,
+                 'ddx': elemdata.ddispersion[:, 0],
                 }
         return twiss
 

--- a/pySC/core/lattice.py
+++ b/pySC/core/lattice.py
@@ -217,10 +217,11 @@ class ATLattice(Lattice):
         else:
             orbit0, _ = at.find_orbit(ring, refpts=indices)
 
-        _, ringdata, elemdata = at.get_optics(ring, refpts=indices, get_chrom=True, orbit=orbit0)
+        _, ringdata, elemdata = at.get_optics(ring, refpts=indices, get_chrom=True, get_w=True, orbit=orbit0)
 
         qs = ringdata['tune'][2] if not self.no_6d else 0 # doesn't exist when ring has 6d disabled
 
+        twopi = 2*np.pi
         twiss = {'qx': elemdata.mu[-1,0]/2/np.pi,
                  'qy': elemdata.mu[-1,1]/2/np.pi,
                  'qs': qs,
@@ -237,12 +238,20 @@ class ATLattice(Lattice):
                  'bety': elemdata.beta[:, 1],
                  'alfx': elemdata.alpha[:, 0],
                  'alfy': elemdata.alpha[:, 1],
-                 'mux': elemdata.mu[:, 0]/2./np.pi,
-                 'muy': elemdata.mu[:, 1]/2./np.pi,
+                 'mux': elemdata.mu[:, 0] / twopi,
+                 'muy': elemdata.mu[:, 1] / twopi,
                  'dx' : elemdata.dispersion[:, 0],
                  'dpx': elemdata.dispersion[:, 1],
                  'dy' : elemdata.dispersion[:, 2],
                  'dpy': elemdata.dispersion[:, 3],
+                 'wx_chrom': elemdata.w[:, 0],
+                 'bx_chrom': elemdata.dbeta[:, 0]/elemdata.beta[:, 0],
+                 'ax_chrom': elemdata.dalpha[:, 0] - (elemdata.alpha[:, 0] / elemdata.beta[:, 0]) * elemdata.dbeta[:, 0],
+                 'wy_chrom': elemdata.w[:, 1],
+                 'by_chrom': elemdata.dbeta[:, 1]/elemdata.beta[:, 1],
+                 'ay_chrom': elemdata.dalpha[:, 1] - (elemdata.alpha[:, 1] / elemdata.beta[:, 1]) * elemdata.dbeta[:, 1],
+                 'dmux': elemdata.dmu[:, 0] / twopi,
+                 'dmuy': elemdata.dmu[:, 1] / twopi,
                 }
         return twiss
 

--- a/pySC/core/xsuite_lattice.py
+++ b/pySC/core/xsuite_lattice.py
@@ -252,6 +252,7 @@ class XSuiteLattice(Lattice):
                  'ay_chrom': tw.ay_chrom,
                  'dmux': tw.dmux,
                  'dmuy': tw.dmuy,
+                 'ddx': tw.ddx,
                 }
         return twiss 
 

--- a/pySC/core/xsuite_lattice.py
+++ b/pySC/core/xsuite_lattice.py
@@ -244,6 +244,14 @@ class XSuiteLattice(Lattice):
                  'dpx': tw.dpx,
                  'dy' : tw.dy,
                  'dpy': tw.dpy,
+                 'wx_chrom': tw.wx_chrom,
+                 'bx_chrom': tw.bx_chrom,
+                 'ax_chrom': tw.ax_chrom,
+                 'wy_chrom': tw.wy_chrom,
+                 'by_chrom': tw.by_chrom,
+                 'ay_chrom': tw.ay_chrom,
+                 'dmux': tw.dmux,
+                 'dmuy': tw.dmuy,
                 }
         return twiss 
 

--- a/pySC/utils/rdt.py
+++ b/pySC/utils/rdt.py
@@ -41,8 +41,8 @@ def feeddown(AB: np.ndarray[complex], r0: complex, n: int):
     maxN = len(AB)
     value = 0j
     for k in range(n, maxN):
-        value += AB[k] * binomial_coeff(k, n) * (r0 ** (k - n))
-    return value 
+        value += AB[k] * binomial_coeff(k, n) * ((-r0) ** (k - n))
+    return value
 
 def omega(x):
     if x%2:
@@ -51,6 +51,9 @@ def omega(x):
         return 1
 
 def get_integrated_strengths_with_feeddown(SC: "SimulatedCommissioning", use_design: bool = False):
+    '''
+    returned integrated strengths are in MAD-X/Xsuite/PALS convention
+    '''
     twiss = SC.lattice.get_twiss(use_design=use_design)
     if use_design:
         magnet_settings = SC.design_magnet_settings
@@ -65,8 +68,9 @@ def get_integrated_strengths_with_feeddown(SC: "SimulatedCommissioning", use_des
 
     for magnet in magnet_settings.magnets.values():
         ii = magnet.sim_index
-        x_co = twiss['x'][ii]
-        y_co = twiss['y'][ii]
+        # average closed_orbit
+        x_co = 0.5*(twiss['x'][ii] + twiss['x'][(ii+1)%N])
+        y_co = 0.5*(twiss['y'][ii] + twiss['y'][(ii+1)%N])
         if not use_design:
             dx, dy = SC.support_system.get_total_offset(ii)
             roll, _, _ = SC.support_system.get_total_rotation(ii)
@@ -82,7 +86,10 @@ def get_integrated_strengths_with_feeddown(SC: "SimulatedCommissioning", use_des
             integrated_strengths['norm'][temp_max_order] = np.zeros(N)
             integrated_strengths['skew'][temp_max_order] = np.zeros(N)
 
-        AB = (np.array(magnet.B) + 1.j*np.array(magnet.A)) * np.exp(1.j*roll) * magnet.length
+        AB = (np.array(magnet.B) + 1.j*np.array(magnet.A)) * np.exp(-1.j*roll) * magnet.length #* FACTORIAL[:len(magnet.B)]
+        # AB needs to be in AT convention here, gets converted to PALS convention later.
+        # TODO: in future we should use PALS only conventions
+        # should integrated_strengths be complex array maybe?
         for jj in range(magnet.max_order + 1):
             AB_with_feeddown = feeddown(AB, r0, jj)
             integrated_strengths['norm'][jj][ii] = AB_with_feeddown.real * FACTORIAL[jj]
@@ -118,7 +125,14 @@ def hjklm(SC: Optional["SimulatedCommissioning"] = None, j: int = 0, k: int = 0,
 
     K = integrated_strengths['norm'][n-1]
     J = integrated_strengths['skew'][n-1]
-    h = - (K * omega(l+m) + 1j * J * omega(l+m+1))/(FACTORIAL[j] * FACTORIAL[k] * FACTORIAL[l] * FACTORIAL[m] * 2**(n)) * (1.j)**(l+m) * twiss['betx']**((j+k)/2) * twiss['bety']**((l+m)/2)
+
+    avbetx = np.zeros_like(twiss['betx'])
+    avbety = np.zeros_like(twiss['betx'])
+    avbetx[:-1] = 0.5*(twiss['betx'][:-1] + twiss['betx'][1:])
+    avbety[:-1] = 0.5*(twiss['bety'][:-1] + twiss['bety'][1:])
+    avbetx[-1] = 0.5*(twiss['betx'][-1] + twiss['betx'][0])
+    avbety[-1] = 0.5*(twiss['bety'][-1] + twiss['bety'][0])
+    h = - (K * omega(l+m) + 1j * J * omega(l+m+1))/(FACTORIAL[j] * FACTORIAL[k] * FACTORIAL[l] * FACTORIAL[m] * 2**(n)) * (1.j)**(l+m) * avbetx**((j+k)/2) * avbety**((l+m)/2)
     return h
 
 
@@ -137,13 +151,22 @@ def fjklm(SC: Optional["SimulatedCommissioning"] = None, j: int = 0, k: int = 0,
     h = hjklm(SC=SC, j=j, k=k, l=l, m=m, use_design=use_design, integrated_strengths=integrated_strengths, twiss=twiss)
     mask = h != 0
     hm = h[mask]
-    mux = twiss['mux'][mask]
-    muy = twiss['muy'][mask]
+
+
+    avmux = np.zeros_like(twiss['mux'])
+    avmuy = np.zeros_like(twiss['mux'])
+    avmux[:-1] = 0.5*(twiss['mux'][:-1] + twiss['mux'][1:])
+    avmuy[:-1] = 0.5*(twiss['muy'][:-1] + twiss['muy'][1:])
+    avmux[-1] = 0.5*(twiss['mux'][-1] + twiss['mux'][0])
+    avmuy[-1] = 0.5*(twiss['muy'][-1] + twiss['muy'][0])
+
+    mux = avmux[mask]
+    muy = avmuy[mask]
     ii = 0
     f = np.zeros_like(twiss['s'], dtype=complex)
     for ii in range(len(twiss['s'])):
-        dphix = 2. * np.pi * (twiss['mux'][ii] - mux)
-        dphiy = 2. * np.pi * (twiss['muy'][ii] - muy)
+        dphix = 2. * np.pi * (avmux[ii] - mux)
+        dphiy = 2. * np.pi * (avmuy[ii] - muy)
         # Wrap negative phase advances around the ring
         dphix = np.where(dphix < 0, dphix + 2. * np.pi * qx, dphix)
         dphiy = np.where(dphiy < 0, dphiy + 2. * np.pi * qy, dphiy)

--- a/pySC/utils/rdt.py
+++ b/pySC/utils/rdt.py
@@ -157,8 +157,8 @@ def fjklm(SC: Optional["SimulatedCommissioning"] = None, j: int = 0, k: int = 0,
     avmuy = np.zeros_like(twiss['mux'])
     avmux[:-1] = 0.5*(twiss['mux'][:-1] + twiss['mux'][1:])
     avmuy[:-1] = 0.5*(twiss['muy'][:-1] + twiss['muy'][1:])
-    avmux[-1] = 0.5*(twiss['mux'][-1] + twiss['mux'][0])
-    avmuy[-1] = 0.5*(twiss['muy'][-1] + twiss['muy'][0])
+    avmux[-1] = 0.5*(twiss['mux'][-1] + twiss['mux'][0] + qx)
+    avmuy[-1] = 0.5*(twiss['muy'][-1] + twiss['muy'][0] + qy)
 
     mux = avmux[mask]
     muy = avmuy[mask]

--- a/tests/core/test_lattice.py
+++ b/tests/core/test_lattice.py
@@ -67,8 +67,25 @@ def test_get_twiss_keys(hmba_lattice_file):
     twiss = lat.get_twiss(use_design=True)
     expected_keys = {'qx', 'qy', 'qs', 'dqx', 'dqy', 's', 'x', 'px', 'y', 'py',
                      'delta', 'tau', 'betx', 'bety', 'alfx', 'alfy', 'mux', 'muy',
-                     'dx', 'dpx', 'dy', 'dpy'}
+                     'dx', 'dpx', 'dy', 'dpy', 'wx_chrom', 'bx_chrom', 'ax_chrom',
+                     'wy_chrom', 'by_chrom', 'ay_chrom', 'dmux', 'dmuy', 'ddx'}
     assert expected_keys.issubset(twiss.keys())
+
+
+def test_get_twiss_chromatic_arrays_match_refpoints(hmba_lattice_file):
+    """Chromatic Twiss arrays have one value per returned refpoint."""
+    lat = ATLattice(lattice_file=hmba_lattice_file)
+    twiss = lat.get_twiss(use_design=True)
+    n_refpts = len(twiss['s'])
+
+    for key in [
+        'wx_chrom', 'bx_chrom', 'ax_chrom',
+        'wy_chrom', 'by_chrom', 'ay_chrom',
+        'dmux', 'dmuy', 'ddx',
+    ]:
+        assert key in twiss
+        assert len(twiss[key]) == n_refpts
+        assert np.all(np.isfinite(twiss[key]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_xsuite_lattice.py
+++ b/tests/core/test_xsuite_lattice.py
@@ -1,0 +1,73 @@
+"""Tests for pySC.core.xsuite_lattice: XSuiteLattice helpers."""
+from types import SimpleNamespace
+
+import numpy as np
+
+from pySC.core.xsuite_lattice import XSuiteLattice
+
+
+class _FakeLine:
+    """Minimal Xsuite line double exposing the twiss API used by XSuiteLattice."""
+
+    def __init__(self, twiss):
+        self._twiss = twiss
+
+    def __len__(self):
+        return len(self._twiss.s)
+
+    def twiss(self, **kwargs):
+        self.last_twiss_kwargs = kwargs
+        return self._twiss
+
+
+def test_xsuite_get_twiss_exposes_chromatic_keys():
+    """XSuiteLattice.get_twiss maps chromatic Twiss fields into pySC keys."""
+    values = np.array([0.0, 1.0, 2.0])
+    twiss_result = SimpleNamespace(
+        qx=0.31,
+        qy=0.32,
+        qs=0.01,
+        dqx=1.0,
+        dqy=2.0,
+        name=np.array(["e0", "e1", "e2"]),
+        s=values,
+        x=values + 0.1,
+        px=values + 0.2,
+        y=values + 0.3,
+        py=values + 0.4,
+        delta=values + 0.5,
+        zeta=values + 0.6,
+        betx=values + 10.0,
+        bety=values + 20.0,
+        alfx=values + 0.7,
+        alfy=values + 0.8,
+        mux=values + 0.9,
+        muy=values + 1.0,
+        dx=values + 1.1,
+        dpx=values + 1.2,
+        dy=values + 1.3,
+        dpy=values + 1.4,
+        wx_chrom=values + 1.5,
+        bx_chrom=values + 1.6,
+        ax_chrom=values + 1.7,
+        wy_chrom=values + 1.8,
+        by_chrom=values + 1.9,
+        ay_chrom=values + 2.0,
+        dmux=values + 2.1,
+        dmuy=values + 2.2,
+        ddx=values + 2.3,
+    )
+    line = _FakeLine(twiss_result)
+    lattice = XSuiteLattice.model_construct(lattice_file="dummy.json", no_6d=False)
+    lattice._design = line
+    lattice._ring = line
+    lattice.num_turns_search_t_rev = 5
+
+    twiss = lattice.get_twiss(use_design=True)
+
+    for key in [
+        'wx_chrom', 'bx_chrom', 'ax_chrom',
+        'wy_chrom', 'by_chrom', 'ay_chrom',
+        'dmux', 'dmuy', 'ddx',
+    ]:
+        np.testing.assert_array_equal(twiss[key], getattr(twiss_result, key))

--- a/tests/utils/test_rdt.py
+++ b/tests/utils/test_rdt.py
@@ -1,10 +1,12 @@
 """Tests for pySC.utils.rdt: Resonance Driving Terms and related functions."""
 import numpy as np
 import pytest
+from types import SimpleNamespace
 
 from pySC.utils.rdt import (
     binomial_coeff,
     feeddown,
+    get_integrated_strengths_with_feeddown,
     omega,
     FACTORIAL,
     S4,
@@ -58,16 +60,16 @@ class TestFeeddown:
             assert result == pytest.approx(AB[n], abs=1e-14)
 
     def test_feeddown_with_offset(self):
-        """feeddown with non-zero r0 includes higher-order contributions."""
+        """feeddown with non-zero r0 uses the pySC RDT sign convention."""
         # For a pure quadrupole: AB = [0, K] (K at index 1)
         K = 1.0 + 0.0j
         AB = np.array([0.0 + 0.0j, K])
         r0 = 0.001 + 0.0j  # 1 mm horizontal offset
 
-        # feeddown(AB, r0, n=0) = AB[0]*C(0,0)*r0^0 + AB[1]*C(1,0)*r0^1
-        #                        = 0 + K * 1 * r0
+        # feeddown(AB, r0, n=0) = AB[0]*C(0,0)*(-r0)^0 + AB[1]*C(1,0)*(-r0)^1
+        #                        = 0 - K * r0
         result = feeddown(AB, r0, n=0)
-        expected = K * r0
+        expected = -K * r0
         assert result == pytest.approx(expected, abs=1e-14)
 
         # feeddown(AB, r0, n=1) = AB[1]*C(1,1)*r0^0 = K
@@ -81,15 +83,46 @@ class TestFeeddown:
         AB = np.array([0.0j, 0.0j, S])
         r0 = 0.002 + 0.001j
 
-        # Feed-down to n=1: S * C(2,1) * r0^1 = S * 2 * r0
+        # Feed-down to n=1: S * C(2,1) * (-r0)^1 = -S * 2 * r0
         result = feeddown(AB, r0, n=1)
-        expected = S * 2 * r0
+        expected = -S * 2 * r0
         assert result == pytest.approx(expected, abs=1e-14)
 
-        # Feed-down to n=0: S * C(2,0) * r0^2 = S * r0^2
+        # Feed-down to n=0: S * C(2,0) * (-r0)^2 = S * r0^2
         result = feeddown(AB, r0, n=0)
         expected = S * r0**2
         assert result == pytest.approx(expected, abs=1e-14)
+
+
+class TestIntegratedStrengthsWithFeeddown:
+    def test_uses_average_closed_orbit_for_feeddown(self):
+        """Feeddown uses the average closed orbit across the magnet element."""
+        magnet = SimpleNamespace(
+            sim_index=1,
+            max_order=1,
+            B=[0.0, 2.0],
+            A=[0.0, 0.0],
+            length=0.5,
+        )
+        twiss = {
+            's': np.array([0.0, 1.0, 2.0]),
+            'x': np.array([0.0, 0.002, 0.004]),
+            'y': np.zeros(3),
+        }
+        sc = SimpleNamespace(
+            lattice=SimpleNamespace(get_twiss=lambda use_design=False: twiss),
+            magnet_settings=SimpleNamespace(magnets={'q1': magnet}),
+            support_system=SimpleNamespace(
+                get_total_offset=lambda index: (0.0, 0.0),
+                get_total_rotation=lambda index: (0.0, 0.0, 0.0),
+            ),
+        )
+
+        strengths = get_integrated_strengths_with_feeddown(sc, use_design=False)
+
+        # x_co = 0.5 * (0.002 + 0.004) = 0.003, r0 = -x_co.
+        # feeddown uses (-r0), so B1 feeddown is K1 * L * x_co.
+        assert strengths['norm'][0][1] == pytest.approx(2.0 * 0.5 * 0.003)
 
 
 class TestRot2D:
@@ -229,6 +262,17 @@ def _make_synthetic_strengths(n_elements=20, sext_indices=None, sext_k2l=50.0):
     return strengths
 
 
+def _average_refpoint_values(values, q=None):
+    """Average neighboring refpoint values, unwrapping the periodic endpoint if needed."""
+    averaged = np.zeros_like(values)
+    averaged[:-1] = 0.5 * (values[:-1] + values[1:])
+    if q is None:
+        averaged[-1] = 0.5 * (values[-1] + values[0])
+    else:
+        averaged[-1] = 0.5 * (values[-1] + values[0] + q)
+    return averaged
+
+
 class TestHjklm:
     """Tests for hjklm using synthetic twiss and integrated strengths."""
 
@@ -339,11 +383,12 @@ class TestFjklm:
         """Compare fjklm against the analytic RDT for a single thin sextupole.
 
         For a single sextupole at index s with integrated strength K2L,
-        the driving term h21000 at that element is:
-          h_s = -K2L / (8 * 1) * betx_s^(3/2)
+        the driving term h21000 at that element is evaluated with element-center
+        averaged optics:
+          h_s = -K2L / (8 * 1) * avbetx_s^(3/2)
         and the RDT at observation point i (unnormalized) is:
           f_i = h_s * exp(i * (j-k) * dphi_x)
-        where dphi_x is the (wrapped) phase advance from s to i.
+        where dphi_x is the wrapped phase advance between averaged phases.
 
         Regression: the original fjklm used np.abs on phase differences,
         which destroyed the sign needed for correct wrapping.
@@ -361,18 +406,45 @@ class TestFjklm:
         f = fjklm(j=2, k=1, l=0, m=0, integrated_strengths=strengths,
                   twiss=twiss, normalized=False)
 
-        # Analytic: h21000 at sextupole location
+        # Analytic: h21000 at sextupole location using averaged element-center optics
         # h = -K2L / (2! * 1! * 0! * 0! * 2^3) * betx^(3/2)
         #   = -K2L / (2 * 1 * 1 * 1 * 8) * betx^(3/2)
         #   = -K2L / 16 * betx^(3/2)
-        betx_s = twiss['betx'][sext_idx]
-        h_analytic = -K2L / 16 * betx_s**(3./2)
+        avbetx = _average_refpoint_values(twiss['betx'])
+        avmux = _average_refpoint_values(twiss['mux'], q=qx)
+        h_analytic = -K2L / 16 * avbetx[sext_idx]**(3./2)
 
         for ii in range(N + 1):
-            dphi = 2 * np.pi * (twiss['mux'][ii] - twiss['mux'][sext_idx])
+            dphi = 2 * np.pi * (avmux[ii] - avmux[sext_idx])
             if dphi < 0:
                 dphi += 2 * np.pi * qx
             # j-k = 1 for h21000
+            f_analytic = h_analytic * np.exp(1j * dphi)
+            np.testing.assert_allclose(f[ii], f_analytic, atol=1e-10,
+                                       err_msg=f"Mismatch at element {ii}")
+
+    def test_fjklm_averages_periodic_endpoint_phase(self):
+        """The final refpoint phase average is unwrapped by one tune."""
+        N = 20
+        qx = 0.31
+        qy = 0.22
+        sext_idx = N
+        K2L = 50.0
+
+        twiss = _make_synthetic_twiss(n_elements=N, qx=qx, qy=qy)
+        strengths = _make_synthetic_strengths(n_elements=N, sext_indices=[sext_idx], sext_k2l=K2L)
+
+        f = fjklm(j=2, k=1, l=0, m=0, integrated_strengths=strengths,
+                  twiss=twiss, normalized=False)
+
+        avbetx = _average_refpoint_values(twiss['betx'])
+        avmux = _average_refpoint_values(twiss['mux'], q=qx)
+        h_analytic = -K2L / 16 * avbetx[sext_idx]**(3./2)
+
+        for ii in range(N + 1):
+            dphi = 2 * np.pi * (avmux[ii] - avmux[sext_idx])
+            if dphi < 0:
+                dphi += 2 * np.pi * qx
             f_analytic = h_analytic * np.exp(1j * dphi)
             np.testing.assert_allclose(f[ii], f_analytic, atol=1e-10,
                                        err_msg=f"Mismatch at element {ii}")


### PR DESCRIPTION
- **Adds chromatic optics fields to Twiss output**
  - `ATLattice.get_twiss()` now calls `at.get_optics(..., get_w=True)` and returns chromatic beta/alpha/phase/dispersion fields:
    - `wx_chrom`, `bx_chrom`, `ax_chrom`
    - `wy_chrom`, `by_chrom`, `ay_chrom`
    - `dmux`, `dmuy`, `ddx`
  - `XSuiteLattice.get_twiss()` exposes the analogous Xsuite Twiss fields.

- **Changes RDT feeddown convention**
  - `feeddown()` now evaluates higher-order feeddown using `(-r0) ** (k - n)` instead of `r0 ** (k - n)`.
  - `get_integrated_strengths_with_feeddown()` now:
    - averages closed orbit across element entrance/exit,
    - uses `dx - x_co + i*(dy - y_co)` for offset,
    - applies roll as `exp(-i*roll)`,
    - documents that returned strengths are in MAD-X/Xsuite/PALS convention.

- **Moves RDT optics/phase evaluation to element-center averages**
  - `hjklm()` now uses averaged beta functions between adjacent refpoints.
  - `fjklm()` now uses averaged phase advances between adjacent refpoints.

One important follow-up: existing `tests/utils/test_rdt.py` still encode the old feeddown/phase convention, so they currently fail unless updated to the new intended convention.